### PR TITLE
Show markdown rendering error to user

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -49,7 +49,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	slide, err := glamour.Render(m.Slides[m.Page], "styles/theme.json")
 	if err != nil {
-		slide = "Error: Could not render markdown!"
+		slide = fmt.Sprintf("Error: Could not render markdown! (%v)", err)
 	}
 	slide = styles.Slide.Render(slide)
 


### PR DESCRIPTION
I had to guess what I missed here:

<img width="1313" alt="screenshot_2021-06-05_23-04-00" src="https://user-images.githubusercontent.com/11699655/120905458-6fc91880-c652-11eb-928a-0afe32fa4e60.png">

However, showing the error directly to the user is very helpful IMO. 🙂 

<img width="1313" alt="screenshot_2021-06-05_23-02-51" src="https://user-images.githubusercontent.com/11699655/120905465-7f486180-c652-11eb-8c2a-c2c6917b0588.png">
