### PR TITLE
Fix #5 Allow to use triple dashes as a slide separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Create a simple markdown file that contains your slides:
 # Welcome to Slides
 A terminal based presentation tool
 
-~~~
+---
 
 ## Everything is markdown
 In fact, this entire presentation is a markdown file.
 
-~~~
+---
 
 ## Everything happens in your terminal
 Create slides and present them without ever leaving your terminal.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const delimiter = "~~~"
+const (
+	delimiter    = "\n---\n"
+	altDelimiter = "\n~~~\n"
+)
 
 var root = &cobra.Command{
 	Use:   "slides <file.md>",
@@ -35,7 +38,9 @@ var root = &cobra.Command{
 			return errors.New("could not read file")
 		}
 
-		slides := strings.Split(string(b), delimiter)
+		content := string(b)
+		content = strings.ReplaceAll(content, altDelimiter, delimiter)
+		slides := strings.Split(content, delimiter)
 
 		user, err := user.Current()
 		if err != nil {

--- a/examples/slides.md
+++ b/examples/slides.md
@@ -1,12 +1,12 @@
 # Welcome to Slides
 A terminal based presentation tool
 
-~~~
+---
 
 ## Everything is markdown
 In fact this entire presentation is a markdown file
 
-~~~
+---
 
 # h1
 ## h2
@@ -27,15 +27,15 @@ You can use everything in markdown!
 | ------ | ------ |
 | Even   | Tables |
 
-~~~
+---
 
-All you need to do is separate slides with triple tildes `\~\~\~`,
-Like so:
+All you need to do is separate slides with triple dashes `---` on a separate line,
+like so:
 
 ```markdown
 Slide 1
 
-\~\~\~
+--- 
 
 Slide 2
 ```


### PR DESCRIPTION
Fixes #5 

### Changes Introduced
- Allow using triple dashes as a slide separator
- Keep old slides separator for backward compatibility
