### PR TITLE
Code execution on slide

### DIFF
--- a/examples/slides.md
+++ b/examples/slides.md
@@ -1,15 +1,10 @@
 # Welcome to Slides
 A terminal based presentation tool
 
-```go
-package main
-
-import "fmt"
-
-func main() {
-  fmt.Println("Written in Go!")
-}
+```ruby
+puts "Hello, world!"
 ```
+Should result in Hello, world!
 
 ---
 


### PR DESCRIPTION
Fixes #9

### Changes Introduced
- Allows any (ruby) code blocks to be executed if one is found
by pressing the `e` key.

(Just a prototype, this solution probably won't work for most lanugages. Going to try a different approach with writing files and creating a `code` package to make it easier to add support for more languages)