### PR TITLE
Execute code on slides

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -1,0 +1,50 @@
+# Code blocks
+
+Slides allows you to execute code blocks directly inside your slides!
+
+Just press `e` and the result of the code block will be displayed as virtual
+text in your slides.
+
+Currently supported languages:
+* `bash`
+* `go`
+* `ruby`
+* `python`
+
+---
+
+### Bash
+
+```bash
+ls
+```
+
+---
+
+### Go
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello, world!")
+}
+```
+
+---
+
+### Ruby
+
+```ruby
+puts "Hello, world!"
+```
+
+---
+
+### Python
+
+```python
+print("Hello, world!")
+```

--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -2,7 +2,7 @@
 
 Slides allows you to execute code blocks directly inside your slides!
 
-Just press `e` and the result of the code block will be displayed as virtual
+Just press `ctrl+e` and the result of the code block will be displayed as virtual
 text in your slides.
 
 Currently supported languages:

--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -21,7 +21,7 @@ type Result struct {
 }
 
 // ?: means non-capture group
-var re = regexp.MustCompile("(?:```|~~~)(.*)\n(.*)\n(?:```|~~~)")
+var re = regexp.MustCompile("(?s)(?:```|~~~)(\\w+)\n(.*)\n(?:```|~~~)\n")
 
 var (
 	ErrParse = errors.New("Error: could not parse code block")

--- a/internal/code/code_test.go
+++ b/internal/code/code_test.go
@@ -37,27 +37,37 @@ fmt.Println("Hello, world!")
 		},
 		{
 			markdown: `
+# Welcome to Slides
+
+A terminal based presentation tool
+
+~~~go
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Written in Go!")
+}
+~~~
+`,
+			expected: code.Block{
+				Code: `package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Written in Go!")
+}`,
+				Language: "go",
+			},
+		},
+		{
+			markdown: `
 # Slide 1
 Just a regular slide, no code block
 `,
 			expected: code.Block{},
-		},
-		{
-			markdown: `
-# Multiple Code Blocks
-~~~go
-fmt.Println("Oh no!")
-~~~
-
-# Secondary Code Block
-~~~ruby
-puts "We will only parse the first code block"
-~~~
-`,
-			expected: code.Block{
-				Code:     `fmt.Println("Oh no!")`,
-				Language: "go",
-			},
 		},
 		{
 			markdown: ``,

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -106,7 +106,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.Page--
 			}
 			m.VirtualText = ""
-		case "e":
+		case "ctrl+e":
 			// Run code block
 			block, err := code.Parse(m.Slides[m.Page])
 			if err != nil {


### PR DESCRIPTION
Fixes #9

### Changes Introduced
Ability to execute code blocks by pressing <kbd>e</kbd> (Want to change this for security reasons).
