### PR TITLE
install required directory is not in a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yay -S slides
 
 * Go
 ```bash
-go install github.com/maaslalani/slides
+go install github.com/maaslalani/slides@latest
 ```
 
 From source:


### PR DESCRIPTION
go install needed "@latest"
required when current directory is not in a module.

Fixes

when doing
$  go install  

add "@latest".

### Changes Introduced
- go snap installed version in ubuntu latest (go version go1.16.5 linux/amd64)
  suggest Try 'go install github.com/maaslalani/slides@latest'
