### PR TITLE
Fix #39, allow code blocks without trailing new line to run

### DIFF
--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -21,7 +21,7 @@ type Result struct {
 }
 
 // ?: means non-capture group
-var re = regexp.MustCompile("(?s)(?:```|~~~)(\\w+)\n(.*)\n(?:```|~~~)\n")
+var re = regexp.MustCompile("(?s)(?:```|~~~)(\\w+)\n(.*)\n(?:```|~~~)\\s?")
 
 var (
 	ErrParse = errors.New("Error: could not parse code block")

--- a/internal/code/code_test.go
+++ b/internal/code/code_test.go
@@ -37,6 +37,16 @@ fmt.Println("Hello, world!")
 		},
 		{
 			markdown: `
+~~~python
+print("Hello, world!")
+~~~`,
+			expected: code.Block{
+				Code:     `print("Hello, world!")`,
+				Language: "python",
+			},
+		},
+		{
+			markdown: `
 # Welcome to Slides
 
 A terminal based presentation tool


### PR DESCRIPTION
Fix #39 