### PR TITLE
Remove `~~~` as a slide delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,6 @@ Create slides and present them without ever leaving your terminal.
 
 ---
 
-## Execute code blocks
-Press `ctrl+e` on a slide with a code block to execute it
-Slides with display the output at the end of the slide.
-
-~~~ruby
-puts "Hello, world!"
-~~~
-
----
-
 Include ASCII graphs with GraphViz + graph-easy.
 https://dot-to-ascii.ggerganov.com/
 
@@ -108,6 +98,8 @@ Go to the previous slide with any of the following keys:
 * <kbd>p</kbd>
 * <kbd>h</kbd>
 * <kbd>j</kbd>
+
+Press <kbd>ctrl+e</kbd> on a slide with a code block to execute it.
 
 ### Configuration
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	delimiter    = "\n---\n"
-	altDelimiter = "\n~~~\n"
+	delimiter = "\n---\n"
 )
 
 type Model struct {
@@ -67,7 +66,6 @@ func (m *Model) Load() error {
 		return err
 	}
 
-	content = strings.ReplaceAll(content, altDelimiter, delimiter)
 	slides := strings.Split(content, delimiter)
 
 	metaData, exists := meta.New().ParseHeader(slides[0])


### PR DESCRIPTION
Fixes #47
Fixes #48 

### Changes Introduced
- Removes `~~~` as a slide delimiter
