### PR TITLE
Pre-process any commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,26 @@ Create slides and present them without ever leaving your terminal.
 
 ---
 
-Include ASCII graphs with GraphViz + graph-easy.
-https://dot-to-ascii.ggerganov.com/
+# Pre-process slides
 
-┌──────────┐     ┌────────────┐     ┌────────┐
-│ GraphViz │ ──▶ │ graph-easy │ ──▶ │ slides │
-└──────────┘     └────────────┘     └────────┘
+You can add a code block with ~~~ and write a command to run before displaying
+the slides, the text inside the code block will be passed as stdin to the command
+and the code block will be replaced with the stdout of the command.
 
+~~~graph-easy --as=boxart
+[ A ] - to -> [ B ]
+~~~
+
+The above will be pre-processed to look like:
+
+┌───┐  to   ┌───┐
+│ A │ ────> │ B │
+└───┘       └───┘
+
+For security reasons, you must pass a file that has execution permissions
+for the slides to be pre-processed.
+
+chmod +x file.md
 ```
 
 Checkout the [example slides](./examples).

--- a/examples/import.md
+++ b/examples/import.md
@@ -1,0 +1,2 @@
+This is just an example of how to import text from other files with
+preprocess.md

--- a/examples/preprocess.md
+++ b/examples/preprocess.md
@@ -1,8 +1,36 @@
 # Slides
 
+You can add a code block with three tildes (~) and write a command to run before displaying
+the slides, the text inside the code block will be passed as stdin to the command
+and the code block will be replaced with the stdout of the command.
+
+```
+~~~graph-easy --as=boxart
+[ A ] - to -> [ B ]
+~~~
+```
+
+The above will be pre-processed to look like:
+
+NOTE: You need `graph-easy` installed and in your `$PATH`
+
+```
+┌───┐  to   ┌───┐
+│ A │ ────> │ B │
+└───┘       └───┘
+```
+
+For security reasons, you must pass a file that has execution permissions
+for the slides to be pre-processed.
+
+```
+chmod +x file.md
+```
+
+---
+
 ~~~sd replaced processed
-This content will be replaced and passed into stdin
-of the command above
+This content will be passed in as stdin and will be replaced.
 ~~~
 
 ---
@@ -11,21 +39,13 @@ Any command will work
 
 ~~~echo "You can do whatever, really"
 This doesn't matter, since it will be replaced by the stdout
-of the command above
+of the command above because the command will disregard stdin.
 ~~~
 
 ---
 
-Pre-process Graphs
+You can use this to import snippets of code from other files:
 
-~~~graph-easy --as=boxart
-[ A ] - to -> [ B ]
+~~~xargs cat
+examples/import.md
 ~~~
-
-The above will be pre-processed to look like:
-
-```
-┌───┐  to   ┌───┐
-│ A │ ────> │ B │
-└───┘       └───┘
-```

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -3,6 +3,7 @@
 package file
 
 import (
+	"io/fs"
 	"os"
 )
 
@@ -15,4 +16,9 @@ func Exists(filepath string) bool {
 		return false
 	}
 	return !info.IsDir()
+}
+
+// IsExecutable returns whether a file has execution permissions
+func IsExecutable(s fs.FileInfo) bool {
+	return s.Mode().Perm()&0111 == 0111
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,6 +1,9 @@
 package file_test
 
 import (
+	"fmt"
+	"io/fs"
+	"os"
 	"testing"
 
 	"github.com/maaslalani/slides/internal/file"
@@ -23,6 +26,47 @@ func TestExists(t *testing.T) {
 				assert.FileExists(t, tt.filepath)
 			}
 			assert.Equal(t, tt.want, isExist)
+		})
+	}
+}
+
+func TestIsExecutable(t *testing.T) {
+	tests := []struct {
+		perm     fs.FileMode
+		expected bool
+	}{
+		{0101, false},
+		{0111, true},
+		{0644, false},
+		{0666, false},
+		{0777, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprint(tc.perm), func(t *testing.T) {
+			tmp, err := os.CreateTemp(os.TempDir(), "slides-*")
+			if err != nil {
+				t.Fatal("failed to create temp file")
+			}
+			defer os.Remove(tmp.Name())
+
+			err = tmp.Chmod(tc.perm)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s, err := tmp.Stat()
+			if err != nil {
+				t.Fatal("failed to stat file")
+			}
+
+			want := tc.expected
+			got := file.IsExecutable(s)
+			if tc.expected != got {
+				t.Log(want)
+				t.Log(got)
+				t.Fatalf("IsExecutable returned an incorrect result, want: %t, got %t", want, got)
+			}
 		})
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/maaslalani/slides/internal/code"
+	"github.com/maaslalani/slides/internal/file"
 	"github.com/maaslalani/slides/internal/meta"
 	"github.com/maaslalani/slides/internal/process"
 	"github.com/maaslalani/slides/styles"
@@ -67,8 +68,6 @@ func (m *Model) Load() error {
 	if err != nil {
 		return err
 	}
-
-	content = process.Pre(content)
 
 	slides := strings.Split(content, delimiter)
 
@@ -162,7 +161,15 @@ func readFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(b), err
+	content := string(b)
+
+	// Pre-process slides if the file is executable to avoid
+	// unintentional code execution when presenting slides
+	if file.IsExecutable(s) {
+		content = process.Pre(content)
+	}
+
+	return content, err
 }
 
 func readStdin() (string, error) {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/maaslalani/slides/internal/code"
 	"github.com/maaslalani/slides/internal/meta"
+	"github.com/maaslalani/slides/internal/process"
 	"github.com/maaslalani/slides/styles"
 )
 
@@ -66,6 +67,8 @@ func (m *Model) Load() error {
 	if err != nil {
 		return err
 	}
+
+	content = process.Pre(content)
 
 	slides := strings.Split(content, delimiter)
 

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -67,3 +67,24 @@ func (b *Block) Execute() {
 
 	b.Output = string(out)
 }
+
+// Pre processes the markdown content by executing the commands necessary and
+// returns the new processed content
+func Pre(content string) string {
+	blocks := Parse(content)
+
+	if len(blocks) <= 0 {
+		return content
+	}
+
+	for _, block := range blocks {
+		// TODO: Use goroutines, if possible
+		block.Execute()
+
+		// If multiple blocks have the same Raw value The will _likely_ have the
+		// same Output value so we can probably optimize this
+		// There may be edge cases, though, since block execution is not deterministic.
+		content = strings.Replace(content, block.Raw, block.Output, 1)
+	}
+	return content
+}


### PR DESCRIPTION
Fixes #51 

### Changes Introduced
- Allow arbitrary commands to be executed for pre-processing slides
- This allows for embedding graphs, diagrams, any output of any command, really

- This is a bit different than code execution because it entirely replaces the block of code with the output of the command with the input in the block.