### PR TITLE
EXECUTE: TEST: Use more common sed instead of sd

### DIFF
--- a/internal/process/execute_test.go
+++ b/internal/process/execute_test.go
@@ -16,7 +16,7 @@ func TestExecute(t *testing.T) {
 		},
 		{
 			block: Block{
-				Command: "sd Find Replace",
+				Command: "sed -e s/Find/Replace/g",
 				Input:   "Find",
 			},
 			want: "Replace",


### PR DESCRIPTION
This patch updates the `sd Find Replace` test case to make use of `sed`
instead of `sd`. This should help tests pass on a wider range of
systems without introducing a testing dependency.

Fixes #60
