### PR TITLE
[WIP] CMD: Add version command flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,15 @@
+project_name: slides
+
+builds:
+- main: ./main.go
+  flags:
+  - -trimpath
+  ldflags:
+  - -X github.com/maaslalani/slides/internal/version.Version={{ .Version }}
+  - -X github.com/maaslalani/slides/internal/version.ShortCommit={{ .ShortCommit }}
+  - -X github.com/maaslalani/slides/internal/version.CommitDate={{ .CommitDate }}
+  goos:
+  - windows
+  - darwin
+  - linux
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,13 +9,15 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/maaslalani/slides/internal/model"
+	"github.com/maaslalani/slides/internal/version"
 	"github.com/spf13/cobra"
 )
 
 var root = &cobra.Command{
-	Use:   "slides <file.md>",
-	Short: "Slides is a terminal based presentation tool",
-	Args:  cobra.MaximumNArgs(1),
+	Use:     "slides <file.md>",
+	Short:   "Slides is a terminal based presentation tool",
+	Args:    cobra.MaximumNArgs(1),
+	Version: version.Version,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		var fileName string
@@ -47,6 +49,11 @@ var root = &cobra.Command{
 }
 
 func Execute() {
+	root.SetVersionTemplate(fmt.Sprintf(
+		version.VersionTemplate,
+		version.Version,
+		version.ShortCommit,
+		version.CommitDate))
 	err := root.Execute()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,15 @@
+package version
+
+// Set at build time with:
+//   -ldflags "-X github.com/maaslalani/slides/internal/version.Version=<v> -X ..."
+var (
+	Version         string = "dev"
+	ShortCommit     string = "unset"
+	CommitDate      string = "date unset"
+	VersionTemplate string = `   _______
+  | # ... |  slides %s
+  | ..... |  Commit %s (%s)
+  |_______|  Copyright (C) 2021 Maas Lalani
+     /|\
+`
+)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,10 +41,26 @@ parts:
     source-type: git
     plugin: go
     go-channel: latest/stable
-        
+
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)"    
+
+    override-build: |
+      version=$(git describe --tags | sed 's/^v//' | cut -d "-" -f1)
+      shortCommit=git rev-parse --short HEAD
+      commitDate=git show -s --format=%cd --date=short
+
+      baseFlag="-X github.com/maaslalani/slides/internal/version"
+      ldFlags="${baseFlag}.Version=${version}"
+      ldFlags="${ldFlags} ${baseFlag}.ShortCommit=${shortCommit}"
+      ldFlags="${ldFlags} ${baseFlag}.CommitDate${commitDate}"
+
+      GO111MODULE=on CGO_ENABLED=0 go build -trimpath -ldflags "${ldFlags" -o slides main.go
+
+      chmod +x slides
+      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
+      mv slides $SNAPCRAFT_PART_INSTALL/bin
 
   homeishome-launch:
     plugin: nil


### PR DESCRIPTION
This patch:

- adds support for a -v or --version command flag. The exact
  values are passed as ldflags at build time; and
- updates the goreleaser and snapcraft yml files to build with
  these values.

The version message looks something like this:

```
~/Projects/slides build-versioning ⇣⇡
❯ go build -ldflags "-X github.com/maaslalani/slides/internal/version.BuildVersion=development -X github.com/maaslalani/slides/internal/version.ShortCommit=testtest -X github.com/maaslalani/slides/internal/version.CommitDate=2021-06-27"

~/Projects/slides build-versioning ⇣⇡
❯ ./slides -v                    
   _______
  | # ... |  slides dev
  | ..... |  Commit testtest (2021-06-27)
  |_______|  Copyright (C) 2021 Maas Lalani
     /|\
```

To pass these ldflags, builds need to have something like the following
added:

```
-ldflags "-X
github.com/maaslalani/slides/internal/version.Version=$Version -X
github.com/maaslalani/slides/internal/version.ShortCommit=$ShortCommit
-X github.com/maaslalani/slides/internal/version.CommitDate=$CommitDate"
```

For GoReleaser, there are `.Version`, `.ShortCommit`, and `.CommitDate`
template values available. An example is also available at
https://goreleaser.com/customization/build/.

Do not pass build dates or times as this will break reproducable builds.
Additionally `-trimpath` needs to be passed during build to account for
different build directories across build systems.