### PR TITLE
Fix preceeding `---` crash

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -3,10 +3,15 @@
 package meta
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/adrg/frontmatter"
 	"gopkg.in/yaml.v2"
+)
+
+var (
+	comment = regexp.MustCompile(`\s*#.*`)
 )
 
 // Meta contains all of the data to be parsed
@@ -28,6 +33,10 @@ func New() *Meta {
 // return false to acknowledge that there is no front matter in this slide
 func (m *Meta) ParseHeader(header string) (*Meta, bool) {
 	fallback := &Meta{Theme: "default"}
+	header = comment.ReplaceAllString(header, "")
+	if len(header) <= 0 {
+		return fallback, false
+	}
 	bytes, err := frontmatter.Parse(strings.NewReader(header), &m)
 	if err != nil {
 		return fallback, false

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -69,7 +69,7 @@ func (m *Model) Load() error {
 		return err
 	}
 
-  content = strings.TrimPrefix(content, strings.TrimPrefix(delimiter, "\n"))
+	content = strings.TrimPrefix(content, strings.TrimPrefix(delimiter, "\n"))
 	slides := strings.Split(content, delimiter)
 
 	metaData, exists := meta.New().ParseHeader(slides[0])

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -69,6 +69,7 @@ func (m *Model) Load() error {
 		return err
 	}
 
+  content = strings.TrimPrefix(content, strings.TrimPrefix(delimiter, "\n"))
 	slides := strings.Split(content, delimiter)
 
 	metaData, exists := meta.New().ParseHeader(slides[0])


### PR DESCRIPTION
- trim prefix delimiter
- remove comments before parsing header

Fixes #77

### Changes Introduced
- Trim preceeding `---` and ensure comments aren't parsed in frontmatter header
