### PR TITLE
fix: bug, preceeding ---, yaml comments

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -3,9 +3,6 @@
 package meta
 
 import (
-	"strings"
-
-	"github.com/adrg/frontmatter"
 	"gopkg.in/yaml.v2"
 )
 
@@ -21,20 +18,25 @@ func New() *Meta {
 	return &Meta{}
 }
 
-// ParseHeader parses metadata from a slideshows header slide
+// Parse parses metadata from a slideshows header slide
 // including theme information
 //
 // If no front matter is provided, it will fallback to the default theme and
 // return false to acknowledge that there is no front matter in this slide
-func (m *Meta) ParseHeader(header string) (*Meta, bool) {
-	fallback := &Meta{Theme: "default"}
-	bytes, err := frontmatter.Parse(strings.NewReader(header), &m)
+func (m *Meta) Parse(header string) (*Meta, bool) {
+	fallback := &Meta{
+		Theme: "default",
+	}
+
+	err := yaml.Unmarshal([]byte(header), &m)
 	if err != nil {
 		return fallback, false
 	}
 
-	err = yaml.Unmarshal(bytes, &m)
-	if err != nil {
+	// This fixes a bug where the first slide of a presentation won't show up if
+	// the first slide is valid YAML (i.e. "# Header")
+	// FIXME: This only works because we currently only have one option (theme),
+	if m.Theme == "" {
 		return fallback, false
 	}
 

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -28,11 +28,18 @@ func TestMeta_ParseHeader(t *testing.T) {
 				Theme: "default",
 			},
 		},
+		{
+			name:      "Fallback if first slide is valid yaml",
+			slideshow: "---\n# Header Slide---\nContent\n",
+			want: &meta.Meta{
+				Theme: "default",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &meta.Meta{}
-			got, hasMeta := m.ParseHeader(tt.slideshow)
+			got, hasMeta := m.Parse(tt.slideshow)
 			if !hasMeta {
 				assert.NotNil(t, got)
 			}
@@ -56,7 +63,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func ExampleMeta_ParseHeader() {
+func ExampleMeta_Parse() {
 	header := `
 ---
 theme: "dark"
@@ -64,7 +71,7 @@ theme: "dark"
 `
 	// Parse the header from the markdown
 	// file
-	m, _ := meta.New().ParseHeader(header)
+	m, _ := meta.New().Parse(header)
 
 	// Print the return theme
 	// meta

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -69,9 +69,10 @@ func (m *Model) Load() error {
 		return err
 	}
 
+	content = strings.TrimPrefix(content, strings.TrimPrefix(delimiter, "\n"))
 	slides := strings.Split(content, delimiter)
 
-	metaData, exists := meta.New().ParseHeader(slides[0])
+	metaData, exists := meta.New().Parse(slides[0])
 	// If the user specifies a custom configuration options
 	// skip the first "slide" since this is all configuration
 	if exists && len(slides) > 1 {


### PR DESCRIPTION
Fixes #https://github.com/maaslalani/slides/issues/77

### Changes Introduced
- Allows preceeding `---`
- Removes dependencies on frontmatter
- Prevents crashing on slides with only valid YAML for first slide
