### PR TITLE
Fix #73, add support for fetching remote theme

### DIFF
--- a/examples/custom_remote_theme.md
+++ b/examples/custom_remote_theme.md
@@ -4,4 +4,4 @@ theme: https://github.com/maaslalani/slides/raw/main/styles/theme.json
 
 # Slides
 
-The above title should be orange and be prefixed with `CUSTOM`.
+The theme of this slide is fetched from https://github.com/maaslalani/slides/raw/main/styles/theme.json, the title above should be green.

--- a/examples/custom_remote_theme.md
+++ b/examples/custom_remote_theme.md
@@ -1,0 +1,7 @@
+---
+theme: https://github.com/maaslalani/slides/raw/main/styles/theme.json
+---
+
+# Slides
+
+The above title should be orange and be prefixed with `CUSTOM`.

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -72,10 +72,12 @@ func SelectTheme(theme string) glamour.TermRendererOption {
 			defer resp.Body.Close()
 			themeReader = resp.Body
 		} else {
-			themeReader, err = os.Open(theme)
+			file, err := os.Open(theme)
 			if err != nil {
 				return getDefaultTheme()
 			}
+			defer file.Close()
+			themeReader = file
 		}
 		bytes, err := io.ReadAll(themeReader)
 		if err == nil {

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -63,7 +63,7 @@ func SelectTheme(theme string) glamour.TermRendererOption {
 	default:
 		var themeReader io.Reader
 		var err error
-		if strings.HasPrefix(theme, "http://") || strings.HasPrefix(theme, "https://") {
+		if strings.HasPrefix(theme, "http") {
 			var resp *http.Response
 			resp, err = http.Get(theme)
 			if err != nil {

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -3,6 +3,8 @@ package styles
 
 import (
 	_ "embed"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -59,20 +61,39 @@ func SelectTheme(theme string) glamour.TermRendererOption {
 	case "notty":
 		return glamour.WithStyles(glamour.NoTTYStyleConfig)
 	default:
-		bytes, err := os.ReadFile(theme)
+		var themeReader io.Reader
+		var err error
+		if strings.HasPrefix(theme, "http://") || strings.HasPrefix(theme, "https://") {
+			var resp *http.Response
+			resp, err = http.Get(theme)
+			if err != nil {
+				return getDefaultTheme()
+			}
+			defer resp.Body.Close()
+			themeReader = resp.Body
+		} else {
+			themeReader, err = os.Open(theme)
+			if err != nil {
+				return getDefaultTheme()
+			}
+		}
+		bytes, err := io.ReadAll(themeReader)
 		if err == nil {
 			return glamour.WithStylesFromJSONBytes(bytes)
 		}
 		// Should log a warning so the user knows we failed to read their theme file
-
-		if termenv.EnvNoColor() {
-			return glamour.WithStyles(glamour.NoTTYStyleConfig)
-		}
-
-		if !termenv.HasDarkBackground() {
-			return glamour.WithStyles(glamour.LightStyleConfig)
-		}
-
-		return glamour.WithStylesFromJSONBytes(DefaultTheme)
+		return getDefaultTheme()
 	}
+}
+
+func getDefaultTheme() glamour.TermRendererOption {
+	if termenv.EnvNoColor() {
+		return glamour.WithStyles(glamour.NoTTYStyleConfig)
+	}
+
+	if !termenv.HasDarkBackground() {
+		return glamour.WithStyles(glamour.LightStyleConfig)
+	}
+
+	return glamour.WithStylesFromJSONBytes(DefaultTheme)
 }


### PR DESCRIPTION
Fix #73, add support for fetching remote theme

### Changes Introduced
- When a theme starts with "http://" or "https://", try fetch it from the internet.
