### PR TITLE
Adds custom user name option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var userName string
+
 var root = &cobra.Command{
 	Use:   "slides <file.md>",
 	Short: "Slides is a terminal based presentation tool",
@@ -24,14 +26,17 @@ var root = &cobra.Command{
 			fileName = args[0]
 		}
 
-		user, err := user.Current()
-		if err != nil {
-			return errors.New("could not get current user")
+		if userName == "" {
+			user, err := user.Current()
+			if err != nil {
+				return errors.New("could not get current user")
+			}
+			userName = user.Name
 		}
 
 		presentation := model.Model{
 			Page:     0,
-			Author:   user.Name,
+			Author:   userName,
 			Date:     time.Now().Format("2006-01-02"),
 			FileName: fileName,
 		}
@@ -47,8 +52,8 @@ var root = &cobra.Command{
 }
 
 func Execute() {
-	err := root.Execute()
-	if err != nil {
+	root.Flags().StringVarP(&userName, "username", "u", "", "Custom user name to show in the footer")
+	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes #90

### Changes Introduced

This is a draft for the implementation suggested in #90 adding a `--username` option to the CLI and just checking for the user if this new option is not in use.