### PR TITLE
Fixes metadata fallback strategy

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -6,10 +6,19 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const defaultTheme = "default"
+
+// Temporary structure to differentiate values not present in the YAML header
+// from values set to empty strings in the YAML header. We replace values not
+// set by defaults values when parsing a header.
+type parsedMeta struct {
+	Theme *string `yaml:"theme"`
+}
+
 // Meta contains all of the data to be parsed
 // out of a markdown file's header section
 type Meta struct {
-	Theme string `yaml:"theme"`
+	Theme string
 }
 
 // New creates a new instance of the
@@ -24,20 +33,18 @@ func New() *Meta {
 // If no front matter is provided, it will fallback to the default theme and
 // return false to acknowledge that there is no front matter in this slide
 func (m *Meta) Parse(header string) (*Meta, bool) {
-	fallback := &Meta{
-		Theme: "default",
-	}
+	fallback := &Meta{Theme: defaultTheme}
 
-	err := yaml.Unmarshal([]byte(header), &m)
+	var tmp parsedMeta
+	err := yaml.Unmarshal([]byte(header), &tmp)
 	if err != nil {
 		return fallback, false
 	}
 
-	// This fixes a bug where the first slide of a presentation won't show up if
-	// the first slide is valid YAML (i.e. "# Header")
-	// FIXME: This only works because we currently only have one option (theme),
-	if m.Theme == "" {
-		return fallback, false
+	if tmp.Theme != nil {
+		m.Theme = *tmp.Theme
+	} else {
+		m.Theme = fallback.Theme
 	}
 
 	return m, true


### PR DESCRIPTION
Fixes #92

### Changes Introduced

I suggest an implementation as described in the issue mentioned above. We used a temporary struct to parse the YAML, and then check its fields. If they were not set, we use a default value, otherwise, we use the parsed value.

The downside is that for every field in `Meta` we need a block such as:

```go
	if tmp.NameOfTheField != nil {
		m.NameOfTheField = *tmp.NameOfTheField
	} else {
		m.NameOfTheField = fallback.NameOfTheField
	}
```

The good part is that we can decide the strategy and defaults for each field (for example, using OS's user name as a default for `author` as suggested in #87).
