### PR TITLE
Adds customization to the bottom metadata

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"os/user"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -24,14 +22,8 @@ var root = &cobra.Command{
 			fileName = args[0]
 		}
 
-		user, err := user.Current()
-		if err != nil {
-			return errors.New("could not get current user")
-		}
-
 		presentation := model.Model{
 			Page:     0,
-			Author:   user.Name,
 			Date:     time.Now().Format("2006-01-02"),
 			FileName: fileName,
 		}

--- a/examples/metadata.md
+++ b/examples/metadata.md
@@ -1,0 +1,31 @@
+---
+author: Gopher
+date: January 2, 2006
+paging: Page %d of %d
+---
+
+# Metadata Example
+
+Customize the bottom information bar by adding metadata to your `slides.md` file.
+
+```
+--- 
+author: Gopher
+date: January 2, 2006
+paging: Page %d of %d
+--- 
+```
+
+---
+
+# Metadata Example
+
+You can also hide the bottom bar by leaving all of the fields blank
+
+```
+--- 
+author: ""
+date: ""
+paging: ""
+--- 
+```

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -12,19 +12,19 @@ import (
 // from values set to empty strings in the YAML header. We replace values not
 // set by defaults values when parsing a header.
 type parsedMeta struct {
-	Theme     *string `yaml:"theme"`
-	Author    *string `yaml:"author"`
-	Date      *string `yaml:"date"`
-	Numbering *string `yaml:"numbering"`
+	Theme  *string `yaml:"theme"`
+	Author *string `yaml:"author"`
+	Date   *string `yaml:"date"`
+	Paging *string `yaml:"paging"`
 }
 
 // Meta contains all of the data to be parsed
 // out of a markdown file's header section
 type Meta struct {
-	Theme     string
-	Author    string
-	Date      string
-	Numbering string
+	Theme  string
+	Author string
+	Date   string
+	Paging string
 }
 
 // New creates a new instance of the
@@ -40,10 +40,10 @@ func New() *Meta {
 // return false to acknowledge that there is no front matter in this slide
 func (m *Meta) Parse(header string) (*Meta, bool) {
 	fallback := &Meta{
-		Theme:     defaultTheme(),
-		Author:    defaultAuthor(),
-		Date:      defaultDate(),
-		Numbering: defaultNumbering(),
+		Theme:  defaultTheme(),
+		Author: defaultAuthor(),
+		Date:   defaultDate(),
+		Paging: defaultPaging(),
 	}
 
 	var tmp parsedMeta
@@ -70,10 +70,10 @@ func (m *Meta) Parse(header string) (*Meta, bool) {
 		m.Date = fallback.Date
 	}
 
-	if tmp.Numbering != nil {
-		m.Numbering = *tmp.Numbering
+	if tmp.Paging != nil {
+		m.Paging = *tmp.Paging
 	} else {
-		m.Numbering = fallback.Numbering
+		m.Paging = fallback.Paging
 	}
 
 	return m, true
@@ -96,6 +96,6 @@ func defaultDate() string {
 	return "2006-01-02"
 }
 
-func defaultNumbering() string {
+func defaultPaging() string {
 	return "Slide %d / %d"
 }

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -3,22 +3,28 @@
 package meta
 
 import (
+	"os/user"
+
 	"gopkg.in/yaml.v2"
 )
-
-const defaultTheme = "default"
 
 // Temporary structure to differentiate values not present in the YAML header
 // from values set to empty strings in the YAML header. We replace values not
 // set by defaults values when parsing a header.
 type parsedMeta struct {
-	Theme *string `yaml:"theme"`
+	Theme     *string `yaml:"theme"`
+	Author    *string `yaml:"author"`
+	Date      *string `yaml:"date"`
+	Numbering *string `yaml:"numbering"`
 }
 
 // Meta contains all of the data to be parsed
 // out of a markdown file's header section
 type Meta struct {
-	Theme string
+	Theme     string
+	Author    string
+	Date      string
+	Numbering string
 }
 
 // New creates a new instance of the
@@ -33,7 +39,12 @@ func New() *Meta {
 // If no front matter is provided, it will fallback to the default theme and
 // return false to acknowledge that there is no front matter in this slide
 func (m *Meta) Parse(header string) (*Meta, bool) {
-	fallback := &Meta{Theme: defaultTheme}
+	fallback := &Meta{
+		Theme:     defaultTheme(),
+		Author:    defaultAuthor(),
+		Date:      defaultDate(),
+		Numbering: defaultNumbering(),
+	}
 
 	var tmp parsedMeta
 	err := yaml.Unmarshal([]byte(header), &tmp)
@@ -47,5 +58,44 @@ func (m *Meta) Parse(header string) (*Meta, bool) {
 		m.Theme = fallback.Theme
 	}
 
+	if tmp.Author != nil {
+		m.Author = *tmp.Author
+	} else {
+		m.Author = fallback.Author
+	}
+
+	if tmp.Date != nil {
+		m.Date = *tmp.Date
+	} else {
+		m.Date = fallback.Date
+	}
+
+	if tmp.Numbering != nil {
+		m.Numbering = *tmp.Numbering
+	} else {
+		m.Numbering = fallback.Numbering
+	}
+
 	return m, true
+}
+
+func defaultTheme() string {
+	return "default"
+}
+
+func defaultAuthor() string {
+	user, err := user.Current()
+	if err != nil {
+		return ""
+	}
+
+	return user.Name
+}
+
+func defaultDate() string {
+	return "2006-01-02"
+}
+
+func defaultNumbering() string {
+	return "Slide %d / %d"
 }

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -2,6 +2,7 @@ package meta_test
 
 import (
 	"fmt"
+	"os/user"
 	"testing"
 
 	"github.com/maaslalani/slides/internal/meta"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestMeta_ParseHeader(t *testing.T) {
+	user, _ := user.Current()
+	date := "2006-01-02"
+
 	tests := []struct {
 		name      string
 		slideshow string
@@ -18,21 +22,90 @@ func TestMeta_ParseHeader(t *testing.T) {
 			name:      "Parse theme from header",
 			slideshow: fmt.Sprintf("---\ntheme: %q\n", "dark"),
 			want: &meta.Meta{
-				Theme: "dark",
+				Theme:     "dark",
+				Author:    user.Name,
+				Date:      date,
+				Numbering: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Fallback to default if no theme provided",
 			slideshow: "\n# Header Slide\n > Subtitle\n",
 			want: &meta.Meta{
-				Theme: "default",
+				Theme:     "default",
+				Author:    user.Name,
+				Date:      date,
+				Numbering: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse author from header",
+			slideshow: fmt.Sprintf("---\nauthor: %q\n", "gopher"),
+			want: &meta.Meta{
+				Theme:     "default",
+				Author:    "gopher",
+				Date:      date,
+				Numbering: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Fallback to default if no author provided",
+			slideshow: "\n# Header Slide\n > Subtitle\n",
+			want: &meta.Meta{
+				Theme:     "default",
+				Author:    user.Name,
+				Date:      date,
+				Numbering: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse date from header",
+			slideshow: fmt.Sprintf("---\ndate: %q\n", "31/01/1970"),
+			want: &meta.Meta{
+				Theme:     "default",
+				Author:    user.Name,
+				Date:      "31/01/1970",
+				Numbering: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Fallback to default if no date provided",
+			slideshow: "\n# Header Slide\n > Subtitle\n",
+			want: &meta.Meta{
+				Theme:     "default",
+				Author:    user.Name,
+				Date:      date,
+				Numbering: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse numbering from header",
+			slideshow: fmt.Sprintf("---\nnumbering: %q\n", "%d of %d"),
+			want: &meta.Meta{
+				Theme:     "default",
+				Author:    user.Name,
+				Date:      date,
+				Numbering: "%d of %d",
+			},
+		},
+		{
+			name:      "Fallback to default if no numebring provided",
+			slideshow: "\n# Header Slide\n > Subtitle\n",
+			want: &meta.Meta{
+				Theme:     "default",
+				Author:    user.Name,
+				Date:      date,
+				Numbering: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Fallback if first slide is valid yaml",
 			slideshow: "---\n# Header Slide---\nContent\n",
 			want: &meta.Meta{
-				Theme: "default",
+				Theme:     "default",
+				Author:    user.Name,
+				Date:      date,
+				Numbering: "Slide %d / %d",
 			},
 		},
 	}
@@ -67,6 +140,9 @@ func ExampleMeta_Parse() {
 	header := `
 ---
 theme: "dark"
+author: "Gopher"
+date: "Apr. 4, 2021"
+numbering: "%d"
 ---
 `
 	// Parse the header from the markdown
@@ -76,4 +152,7 @@ theme: "dark"
 	// Print the return theme
 	// meta
 	fmt.Println(m.Theme)
+	fmt.Println(m.Author)
+	fmt.Println(m.Date)
+	fmt.Println(m.Numbering)
 }

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -22,90 +22,90 @@ func TestMeta_ParseHeader(t *testing.T) {
 			name:      "Parse theme from header",
 			slideshow: fmt.Sprintf("---\ntheme: %q\n", "dark"),
 			want: &meta.Meta{
-				Theme:     "dark",
-				Author:    user.Name,
-				Date:      date,
-				Numbering: "Slide %d / %d",
+				Theme:  "dark",
+				Author: user.Name,
+				Date:   date,
+				Paging: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Fallback to default if no theme provided",
 			slideshow: "\n# Header Slide\n > Subtitle\n",
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    user.Name,
-				Date:      date,
-				Numbering: "Slide %d / %d",
+				Theme:  "default",
+				Author: user.Name,
+				Date:   date,
+				Paging: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Parse author from header",
 			slideshow: fmt.Sprintf("---\nauthor: %q\n", "gopher"),
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    "gopher",
-				Date:      date,
-				Numbering: "Slide %d / %d",
+				Theme:  "default",
+				Author: "gopher",
+				Date:   date,
+				Paging: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Fallback to default if no author provided",
 			slideshow: "\n# Header Slide\n > Subtitle\n",
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    user.Name,
-				Date:      date,
-				Numbering: "Slide %d / %d",
+				Theme:  "default",
+				Author: user.Name,
+				Date:   date,
+				Paging: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Parse date from header",
 			slideshow: fmt.Sprintf("---\ndate: %q\n", "31/01/1970"),
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    user.Name,
-				Date:      "31/01/1970",
-				Numbering: "Slide %d / %d",
+				Theme:  "default",
+				Author: user.Name,
+				Date:   "31/01/1970",
+				Paging: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Fallback to default if no date provided",
 			slideshow: "\n# Header Slide\n > Subtitle\n",
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    user.Name,
-				Date:      date,
-				Numbering: "Slide %d / %d",
+				Theme:  "default",
+				Author: user.Name,
+				Date:   date,
+				Paging: "Slide %d / %d",
 			},
 		},
 		{
-			name:      "Parse numbering from header",
-			slideshow: fmt.Sprintf("---\nnumbering: %q\n", "%d of %d"),
+			name:      "Parse paging from header",
+			slideshow: fmt.Sprintf("---\npaging: %q\n", "%d of %d"),
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    user.Name,
-				Date:      date,
-				Numbering: "%d of %d",
+				Theme:  "default",
+				Author: user.Name,
+				Date:   date,
+				Paging: "%d of %d",
 			},
 		},
 		{
 			name:      "Fallback to default if no numebring provided",
 			slideshow: "\n# Header Slide\n > Subtitle\n",
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    user.Name,
-				Date:      date,
-				Numbering: "Slide %d / %d",
+				Theme:  "default",
+				Author: user.Name,
+				Date:   date,
+				Paging: "Slide %d / %d",
 			},
 		},
 		{
 			name:      "Fallback if first slide is valid yaml",
 			slideshow: "---\n# Header Slide---\nContent\n",
 			want: &meta.Meta{
-				Theme:     "default",
-				Author:    user.Name,
-				Date:      date,
-				Numbering: "Slide %d / %d",
+				Theme:  "default",
+				Author: user.Name,
+				Date:   date,
+				Paging: "Slide %d / %d",
 			},
 		},
 	}
@@ -142,7 +142,7 @@ func ExampleMeta_Parse() {
 theme: "dark"
 author: "Gopher"
 date: "Apr. 4, 2021"
-numbering: "%d"
+paging: "%d"
 ---
 `
 	// Parse the header from the markdown
@@ -154,5 +154,5 @@ numbering: "%d"
 	fmt.Println(m.Theme)
 	fmt.Println(m.Author)
 	fmt.Println(m.Date)
-	fmt.Println(m.Numbering)
+	fmt.Println(m.Paging)
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -25,14 +25,14 @@ const (
 )
 
 type Model struct {
-	Slides    []string
-	Page      int
-	Author    string
-	Date      string
-	Theme     glamour.TermRendererOption
-	Numbering string
-	FileName  string
-	viewport  viewport.Model
+	Slides   []string
+	Page     int
+	Author   string
+	Date     string
+	Theme    glamour.TermRendererOption
+	Paging   string
+	FileName string
+	viewport viewport.Model
 	// VirtualText is used for additional information that is not part of the
 	// original slides, it will be displayed on a slide and reset on page change
 	VirtualText string
@@ -83,7 +83,7 @@ func (m *Model) Load() error {
 	m.Slides = slides
 	m.Author = metaData.Author
 	m.Date = time.Now().Format(metaData.Date)
-	m.Numbering = metaData.Numbering
+	m.Paging = metaData.Paging
 	if m.Theme == nil {
 		m.Theme = styles.SelectTheme(metaData.Theme)
 	}
@@ -149,19 +149,19 @@ func (m Model) View() string {
 	slide = styles.Slide.Render(slide)
 
 	left := styles.Author.Render(m.Author) + styles.Date.Render(m.Date)
-	right := styles.Page.Render(m.numbering())
+	right := styles.Page.Render(m.paging())
 	status := styles.Status.Render(styles.JoinHorizontal(left, right, m.viewport.Width))
 	return styles.JoinVertical(slide, status, m.viewport.Height)
 }
 
-func (m *Model) numbering() string {
-	switch strings.Count(m.Numbering, "%d") {
+func (m *Model) paging() string {
+	switch strings.Count(m.Paging, "%d") {
 	case 2:
-		return fmt.Sprintf(m.Numbering, m.Page+1, len(m.Slides))
+		return fmt.Sprintf(m.Paging, m.Page+1, len(m.Slides))
 	case 1:
-		return fmt.Sprintf(m.Numbering, m.Page+1)
+		return fmt.Sprintf(m.Paging, m.Page+1)
 	default:
-		return m.Numbering
+		return m.Paging
 	}
 }
 


### PR DESCRIPTION

Fixes #87 by adding the fields `Author`, `Date` and `Numbering` in the `Meta` struct.

Not sure where/how to document what I had in mind, so I drafted this table:

| Field | Default | Behavior os the custom value |
|---|---|---|
| `Auhtor` | Current OS user's full name | The string from the YAML replaces the name (including an empty string) |
| `Date` | Today's date in the `YYYY-MM-DD` format | If the date passed is a valid form of `2006-01-02`, it is used to format today's date, otherwise, it just replaces the date with this string |
| `Numbering` | `"Slide %d / %d"` | If the value contains one occurrence of `%d` it is used in `fmt.Sprintf` with the current slide number; if it contains 2, with the current slide number first and the total slide number last; otherwise, it just replaces the numbering with this string |