### PR TITLE
bump glamour to fix bug in orderedList

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/chroma v0.9.2 // indirect
 	github.com/charmbracelet/bubbles v0.8.0
 	github.com/charmbracelet/bubbletea v0.14.2-0.20210802170552-2792304416db
-	github.com/charmbracelet/glamour v0.3.0
+	github.com/charmbracelet/glamour v0.3.1-0.20210812014529-49f2da7feda6 // anything after v0.3.0 for orderedList fix
 	github.com/charmbracelet/lipgloss v0.3.0
 	github.com/microcosm-cc/bluemonday v1.0.15 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/charmbracelet/bubbles v0.8.0/go.mod h1:5WX1sSSjNCgCrzvRMN/z23HxvWaa+A
 github.com/charmbracelet/bubbletea v0.13.1/go.mod h1:tp9tr9Dadh0PLhgiwchE5zZJXm5543JYjHG9oY+5qSg=
 github.com/charmbracelet/bubbletea v0.14.2-0.20210802170552-2792304416db h1:46BFhcFaj783PM/O0xt7f5NXliIthtOf/uARwyCd1Tk=
 github.com/charmbracelet/bubbletea v0.14.2-0.20210802170552-2792304416db/go.mod h1:YTZSs2p3odhwYZdhqJheYHVUjU37c9OLgS85kw6NGQY=
-github.com/charmbracelet/glamour v0.3.0 h1:3H+ZrKlSg8s+WU6V7eF2eRVYt8lCueffbi7r2+ffGkc=
-github.com/charmbracelet/glamour v0.3.0/go.mod h1:TzF0koPZhqq0YVBNL100cPHznAAjVj7fksX2RInwjGw=
+github.com/charmbracelet/glamour v0.3.1-0.20210812014529-49f2da7feda6 h1:O/FeNcl9ULNJ93N7v9ZMcLCroTSCqfZ1LNgkgAdgfAs=
+github.com/charmbracelet/glamour v0.3.1-0.20210812014529-49f2da7feda6/go.mod h1:TzF0koPZhqq0YVBNL100cPHznAAjVj7fksX2RInwjGw=
 github.com/charmbracelet/lipgloss v0.1.2/go.mod h1:5D8zradw52m7QmxRF6QgwbwJi9je84g8MkWiGN07uKg=
 github.com/charmbracelet/lipgloss v0.3.0 h1:5MysOD6sHr4RP4jkZNWGVIul5GKoOsP12NgbgXPvAlA=
 github.com/charmbracelet/lipgloss v0.3.0/go.mod h1:VkhdBS2eNAmRkTwRKLJCFhCOVkjntMusBDxv7TXahuk=


### PR DESCRIPTION
Fixes #88

### Changes Introduced
- just a `go.mod`/`go.sum` change to bump `glamour`.  If you're not keen on using an untagged version, I totally understand and will wait for their release process.  The version corresponds to [`49f2da7feda65ff4f68578b7f8d4eb2fb72e07ee`](https://github.com/charmbracelet/glamour/commit/49f2da7feda65ff4f68578b7f8d4eb2fb72e07ee), which is currently `HEAD` of `master`