### PR TITLE
Uses custom date format YYYY-MM-DD

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,27 @@ paging: Slide %d / %d
   be a link to a remote `json` file which slides will fetch before presenting.
 * `author`: A `string` to display on the bottom-left corner of the presentation
   view. Defaults to the OS current user's full name. Can be empty to hide the author.
-* `date`: A `string` that is used to format today's date in the form
-  `2006-01-02`. If the date is not a valid form of `2006-01-02` the contents of
-  the string will be displayed. Defaults to `2006-01-02`.
+* `date`: A `string` that is used to format today's date in the native Go
+  format `2006-01-02` or in the `YYYY-MM-DD` format. If the date is not a valid
+  format, the string will be displayed. Defaults to `2006-01-02`.
 * `paging`: A `string` that contains 0 or more `%d` directives. The first `%d`
   will be replaced with the current slide number and the second `%d` will be
   replaced with the total slides count. Defaults to `Slide %d / %d`.
+
+#### Date format
+
+Given the date _January 02, 2006_:
+
+| Value  | Translates to |
+|--------|---------------|
+| `YYYY` | 2006          |
+| `YY`   | 06            |
+| `MMMM` | January       |
+| `MMM`  | Jan           |
+| `MM`   | 01            |
+| `mm`   | 1             |
+| `DD`   | 02            |
+| `dd`   | 2             |
 
 ### Alternatives
 

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -4,6 +4,7 @@ package meta
 
 import (
 	"os/user"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -65,7 +66,7 @@ func (m *Meta) Parse(header string) (*Meta, bool) {
 	}
 
 	if tmp.Date != nil {
-		m.Date = *tmp.Date
+		m.Date = parseDate(*tmp.Date)
 	} else {
 		m.Date = fallback.Date
 	}
@@ -98,4 +99,22 @@ func defaultDate() string {
 
 func defaultPaging() string {
 	return "Slide %d / %d"
+}
+
+func parseDate(value string) string {
+	pairs := [][]string{
+		{"YYYY", "2006"},
+		{"YY", "06"},
+		{"MMMM", "January"},
+		{"MMM", "Jan"},
+		{"MM", "01"},
+		{"mm", "1"},
+		{"DD", "02"},
+		{"dd", "2"},
+	}
+
+	for _, p := range pairs {
+		value = strings.ReplaceAll(value, p[0], p[1])
+	}
+	return value
 }

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -59,12 +59,62 @@ func TestMeta_ParseHeader(t *testing.T) {
 			},
 		},
 		{
-			name:      "Parse date from header",
+			name:      "Parse static date from header",
 			slideshow: fmt.Sprintf("---\ndate: %q\n", "31/01/1970"),
 			want: &meta.Meta{
 				Theme:  "default",
 				Author: user.Name,
 				Date:   "31/01/1970",
+				Paging: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse go-styled date from header",
+			slideshow: fmt.Sprintf("---\ndate: %q\n", "Jan 2, 2006"),
+			want: &meta.Meta{
+				Theme:  "default",
+				Author: user.Name,
+				Date:   "Jan 2, 2006",
+				Paging: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse YYYY-MM-DD date from header",
+			slideshow: fmt.Sprintf("---\ndate: %q\n", "YYYY-MM-DD"),
+			want: &meta.Meta{
+				Theme:  "default",
+				Author: user.Name,
+				Date:   "2006-01-02",
+				Paging: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse dd/mm/YY date from header",
+			slideshow: fmt.Sprintf("---\ndate: %q\n", "dd/mm/YY"),
+			want: &meta.Meta{
+				Theme:  "default",
+				Author: user.Name,
+				Date:   "2/1/06",
+				Paging: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse MMM dd, YYYY date from header",
+			slideshow: fmt.Sprintf("---\ndate: %q\n", "MMM dd, YYYY"),
+			want: &meta.Meta{
+				Theme:  "default",
+				Author: user.Name,
+				Date:   "Jan 2, 2006",
+				Paging: "Slide %d / %d",
+			},
+		},
+		{
+			name:      "Parse MMMM DD, YYYY date from header",
+			slideshow: fmt.Sprintf("---\ndate: %q\n", "MMMM DD, YYYY"),
+			want: &meta.Meta{
+				Theme:  "default",
+				Author: user.Name,
+				Date:   "January 02, 2006",
 				Paging: "Slide %d / %d",
 			},
 		},


### PR DESCRIPTION
This PR addresses the issue #106, offering users the possibility to use standard `YYYY-MM-DD` format in the date metadata. It offers the following possibilities:


| Value  | Translates to |
|--------|---------------|
| `YYYY` | 2006          |
| `YY`   | 06            |
| `MMMM` | January       |
| `MMM`  | Jan           |
| `MM`   | 01            |
| `mm`   | 1             |
| `DD`   | 02            |
| `dd`   | 2             |