### PR TITLE
fix: do not get `stderr` when preprocessing slides

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -60,7 +60,7 @@ func (b *Block) Execute() {
 		_, _ = io.WriteString(stdin, b.Input)
 	}()
 
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fixes #144 

### Changes Introduced
- `s/CombinedOutput/Output/g`
