### PR TITLE
fix: `GLAMOUR_STYLE` not `GLAMOUR_THEME`

### DIFF
--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -82,7 +82,7 @@ func (m *Meta) Parse(header string) (*Meta, bool) {
 }
 
 func defaultTheme() string {
-	theme := os.Getenv("GLAMOUR_THEME")
+	theme := os.Getenv("GLAMOUR_STYLE")
 	if theme == "" {
 		return "default"
 	}


### PR DESCRIPTION
Fixes #142

### Changes Introduced
- Variable is called `GLAMOUR_STYLE` not `GLAMOUR_THEME`
