### PR TITLE
feat: copy code blocks

### DIFF
--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/atotto/clipboard"
 )
 
 type Block struct {
@@ -141,4 +143,9 @@ func Execute(code Block) Result {
 		ExitCode:      exitCode,
 		ExecutionTime: end.Sub(start),
 	}
+}
+
+// Copy copies the contents of a code block to the clipboard.
+func Copy(block Block) error {
+	return clipboard.WriteAll(block.Code)
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -157,6 +157,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				outs = append(outs, res.Out)
 			}
 			m.VirtualText = strings.Join(outs, "\n")
+		case "c":
+			// copy code blocks to clipboard
+			blocks, err := code.Parse(m.Slides[m.Page])
+			if err != nil {
+				// We couldn't parse the code block on the screen
+				m.VirtualText = "\n" + err.Error()
+				return m, nil
+			}
+			for _, block := range blocks {
+				err := code.Copy(block)
+				if err != nil {
+					m.VirtualText = "\n" + err.Error()
+					return m, nil
+				}
+			}
+			if len(blocks) > 1 {
+				m.VirtualText = "\n" + "copied code blocks to clipboard"
+			} else {
+				m.VirtualText = "\n" + "copied code block to clipboard"
+			}
+			return m, nil
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		default:


### PR DESCRIPTION
### Changes Introduced
- <kbd>c</kbd> will copy code blocks to clipboard. 

Currently, all blocks are copied individually in order.  So the last code block will be on top of the "clipboard stack"  if you use a clipboard manager. You could concatenate all blocks and copy them to the clipboard as a single entry.

Or, you could have slightly nicer behavior by having <kbd>c</kbd> copy a single block and then maintain a counter that tracks which block should be copied next and then have <kbd>C</kbd> concatenate all blocks into a single clipboard entry. 

