### PR TITLE
feat: ensure that date strings are not interpreted as January 2, 2006 formatted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ chmod +x file.md
 ---
 theme: ./path/to/theme.json
 author: Gopher
-date: January 2, 2006
+date: MMMM dd, YYYY
 paging: Slide %d / %d
 ---
 ```
@@ -220,9 +220,8 @@ paging: Slide %d / %d
   be a link to a remote `json` file which slides will fetch before presenting.
 * `author`: A `string` to display on the bottom-left corner of the presentation
   view. Defaults to the OS current user's full name. Can be empty to hide the author.
-* `date`: A `string` that is used to format today's date in the native Go
-  format `2006-01-02` or in the `YYYY-MM-DD` format. If the date is not a valid
-  format, the string will be displayed. Defaults to `2006-01-02`.
+* `date`: A `string` that is used to format today's date in the `YYYY-MM-DD` format. If the date is not a valid
+  format, the string will be displayed. Defaults to `YYYY-MM-DD`.
 * `paging`: A `string` that contains 0 or more `%d` directives. The first `%d`
   will be replaced with the current slide number and the second `%d` will be
   replaced with the total slides count. Defaults to `Slide %d / %d`.

--- a/examples/metadata.md
+++ b/examples/metadata.md
@@ -1,6 +1,6 @@
 ---
 author: Gopher
-date: January 2, 2006
+date: May 22, 2022
 paging: Page %d of %d
 ---
 
@@ -11,7 +11,7 @@ Customize the bottom information bar by adding metadata to your `slides.md` file
 ```
 --- 
 author: Gopher
-date: January 2, 2006
+date: May 22, 2022
 paging: Page %d of %d
 --- 
 ```

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -67,7 +68,12 @@ func (m *Meta) Parse(header string) (*Meta, bool) {
 	}
 
 	if tmp.Date != nil {
-		m.Date = parseDate(*tmp.Date)
+		parsedDate := parseDate(*tmp.Date)
+		if parsedDate == *tmp.Date {
+			m.Date = *tmp.Date
+		} else {
+			m.Date = time.Now().Format(parsedDate)
+		}
 	} else {
 		m.Date = fallback.Date
 	}
@@ -99,7 +105,7 @@ func defaultAuthor() string {
 }
 
 func defaultDate() string {
-	return "2006-01-02"
+	return time.Now().Format(parseDate("YYYY-MM-DD"))
 }
 
 func defaultPaging() string {

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/user"
 	"testing"
+	"time"
 
 	"github.com/maaslalani/slides/internal/meta"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ import (
 
 func TestMeta_ParseHeader(t *testing.T) {
 	user, _ := user.Current()
-	date := "2006-01-02"
+	date := time.Now().Format("2006-01-02")
 
 	tests := []struct {
 		name      string
@@ -70,11 +71,11 @@ func TestMeta_ParseHeader(t *testing.T) {
 		},
 		{
 			name:      "Parse go-styled date from header",
-			slideshow: fmt.Sprintf("---\ndate: %q\n", "Jan 2, 2006"),
+			slideshow: fmt.Sprintf("---\ndate: %q\n", "MMM dd, YYYY"),
 			want: &meta.Meta{
 				Theme:  "default",
 				Author: user.Name,
-				Date:   "Jan 2, 2006",
+				Date:   time.Now().Format("Jan 2, 2006"),
 				Paging: "Slide %d / %d",
 			},
 		},
@@ -84,7 +85,7 @@ func TestMeta_ParseHeader(t *testing.T) {
 			want: &meta.Meta{
 				Theme:  "default",
 				Author: user.Name,
-				Date:   "2006-01-02",
+				Date:   time.Now().Format("2006-01-02"),
 				Paging: "Slide %d / %d",
 			},
 		},
@@ -94,7 +95,7 @@ func TestMeta_ParseHeader(t *testing.T) {
 			want: &meta.Meta{
 				Theme:  "default",
 				Author: user.Name,
-				Date:   "2/1/06",
+				Date:   time.Now().Format("2/1/06"),
 				Paging: "Slide %d / %d",
 			},
 		},
@@ -104,7 +105,7 @@ func TestMeta_ParseHeader(t *testing.T) {
 			want: &meta.Meta{
 				Theme:  "default",
 				Author: user.Name,
-				Date:   "Jan 2, 2006",
+				Date:   time.Now().Format("Jan 2, 2006"),
 				Paging: "Slide %d / %d",
 			},
 		},
@@ -114,7 +115,7 @@ func TestMeta_ParseHeader(t *testing.T) {
 			want: &meta.Meta{
 				Theme:  "default",
 				Author: user.Name,
-				Date:   "January 02, 2006",
+				Date:   time.Now().Format("January 02, 2006"),
 				Paging: "Slide %d / %d",
 			},
 		},

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -91,7 +91,7 @@ func (m *Model) Load() error {
 
 	m.Slides = slides
 	m.Author = metaData.Author
-	m.Date = time.Now().Format(metaData.Date)
+	m.Date = metaData.Date
 	m.Paging = metaData.Paging
 	if m.Theme == nil {
 		m.Theme = styles.SelectTheme(metaData.Theme)


### PR DESCRIPTION
Fixes #https://github.com/maaslalani/slides/issues/152

### Changes Introduced
- Deprecates `2006-01-02` strings in favour of `YYYY-MM-DD` strings.
- Interprets all non-parse-able dates as static strings.
