### PR TITLE
Code Comments to hide verbose code

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -6,6 +6,8 @@ Just press `ctrl+e` and the result of the code block will be displayed as virtua
 
 Currently supported languages:
 
+<!-- Use comments in your markdown! -->
+
 * `bash`
 * `elixir`
 * `go`
@@ -14,6 +16,7 @@ Currently supported languages:
 * `ruby`
 * `perl`
 * `rust`
+<!-- * `secret` -->
 
 ---
 
@@ -35,14 +38,22 @@ IO.puts "Hello, world!"
 
 ### Go
 
+Use `///` to hide verbose code but still allow the ability to execute it.
+
+If you press `y` to copy (yank) this code block it will return the full snippet.
+
+And, if you press `ctrl+e` it will run the program without error, even though
+what is being displayed is not a valid go program because we have commented out
+some boilerplate to focus on the important parts.
+
 ```go
-package main
-
+///package main
+///
 import "fmt"
-
-func main() {
-  fmt.Println("Hello, world!")
-}
+///
+///func main() {
+fmt.Println("Hello, world!")
+///}
 ```
 
 ---

--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -48,7 +48,7 @@ func Parse(markdown string) ([]Block, error) {
 		}
 		rv = append(rv, Block{
 			Language: match[1],
-			Code:     match[2],
+			Code:     RemoveComments(match[2]),
 		})
 
 	}

--- a/internal/code/comments.go
+++ b/internal/code/comments.go
@@ -1,0 +1,21 @@
+package code
+
+import (
+	"regexp"
+	"strings"
+)
+
+const comment = "///"
+
+var commentRegexp = regexp.MustCompile("(?m)[\r\n]+^" + comment + ".*$")
+
+// HideComments removes all comments from the given content.
+func HideComments(content string) string {
+	return commentRegexp.ReplaceAllString(content, "")
+}
+
+// RemoveComments strips all the comments from the given content.
+// This is useful for when we want to actually use the content of the comments.
+func RemoveComments(content string) string {
+	return strings.ReplaceAll(content, comment, "")
+}

--- a/internal/code/comments_test.go
+++ b/internal/code/comments_test.go
@@ -1,0 +1,64 @@
+package code
+
+import "testing"
+
+func TestHidesComments(t *testing.T) {
+	content := `
+///package main
+///
+///import "fmt"
+///
+///func main() {
+  fmt.Println("Hello, world!")
+///}`
+
+	expected := `
+  fmt.Println("Hello, world!")`
+
+	if HideComments(content) != expected {
+		t.Errorf("Expected %s, got %s", expected, HideComments(content))
+	}
+}
+
+func TestNoComments(t *testing.T) {
+	content := `
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello, world!")
+}`
+	expected := content
+
+	if HideComments(content) != expected {
+		t.Errorf("Expected %s, got %s", expected, HideComments(content))
+	}
+	if RemoveComments(content) != expected {
+		t.Errorf("Expected %s, got %s", expected, HideComments(content))
+	}
+}
+
+func TestRemoveComments(t *testing.T) {
+	content := `
+///package main
+///
+///import "fmt"
+///
+///func main() {
+  fmt.Println("Hello, world!")
+///}`
+
+	expected := `
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello, world!")
+}`
+
+	if RemoveComments(content) != expected {
+		t.Errorf("Expected %s, got %s", expected, RemoveComments(content))
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -204,6 +204,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) View() string {
 	r, _ := glamour.NewTermRenderer(m.Theme, glamour.WithWordWrap(m.viewport.Width))
 	slide := m.Slides[m.Page]
+	slide = code.HideComments(slide)
 	slide, err := r.Render(slide)
 	slide += m.VirtualText
 	if err != nil {


### PR DESCRIPTION
Fixes #135

### Changes Introduced
- Ability to add comments that are not displayed to the user but used in the
  execution of the program and when copying code blocks.
