### PR TITLE
feat: add support for java code execution

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -16,6 +16,7 @@ Currently supported languages:
 * `ruby`
 * `perl`
 * `rust`
+* `java`
 <!-- * `secret` -->
 
 ---
@@ -103,5 +104,16 @@ print ("hello, world");
 ```rust
 fn main() {
     println!("Hello, world!");
+}
+```
+
+---
+
+### Java
+```java
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
 }
 ```

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -25,6 +25,7 @@ const (
 	Python     = "python"
 	Ruby       = "ruby"
 	Rust       = "rust"
+    Java       = "java"
 )
 
 // Languages is a map of supported languages with their extensions and commands
@@ -70,5 +71,9 @@ var Languages = map[string]Language{
 			// run compiled file
 			{"<path>/<name>.run"},
 		},
+	},
+	Java: {
+		Extension: "java",
+		Commands:  cmds{{"java", "<file>"}},
 	},
 }


### PR DESCRIPTION
As of Java 11 a single file can be launched without explicitly
compiling, packaging and running the file in different steps.
In other words single-file source-code programs can be executed
with "java Program.java", where "Program.java" is the name of
the file to be executed.