### PR TITLE
Add support for ZSH

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -9,6 +9,7 @@ Currently supported languages:
 <!-- Use comments in your markdown! -->
 
 * `bash`
+* `zsh`
 * `elixir`
 * `go`
 * `javascript`
@@ -25,6 +26,14 @@ Currently supported languages:
 ### Bash
 
 ```bash
+ls
+```
+
+---
+
+### Zsh
+
+```zsh
 ls
 ```
 

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -17,6 +17,7 @@ type Language struct {
 // Supported Languages
 const (
 	Bash       = "bash"
+	Zsh        = "zsh"
 	Elixir     = "elixir"
 	Go         = "go"
 	Javascript = "javascript"
@@ -36,6 +37,10 @@ var Languages = map[string]Language{
 	Bash: {
 		Extension: "sh",
 		Commands:  cmds{{"bash", "<file>"}},
+	},
+	Zsh: {
+		Extension: "zsh",
+		Commands:  cmds{{"zsh", "<file>"}},
 	},
 	Elixir: {
 		Extension: "exs",


### PR DESCRIPTION
Add support for `zsh` (shell) in addition to `bash`. Its usage is pretty wide-spread so I feel it is justified to add in addition to `bash`.

### Changes Introduced
- Add support for zsh
