### PR TITLE
Add support for Swift

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -18,6 +18,7 @@ Currently supported languages:
 * `rust`
 * `java`
 * `cpp`
+* `swift`
 <!-- * `secret` -->
 
 ---
@@ -134,4 +135,11 @@ int main() {
     std::cout << "Hello, world!" << std::endl;
     return 0;
 }
+```
+
+---
+
+### Swift
+```swift
+print("Hello, world!")
 ```

--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -127,6 +127,8 @@ public class Main {
 println("Hello, world!")
 ```
 
+---
+
 ### C++
 ```cpp
 #include <iostream>

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -28,6 +28,7 @@ const (
 	Java       = "java"
 	Julia      = "julia"
 	Cpp        = "cpp"
+	Swift      = "swift"
 )
 
 // Languages is a map of supported languages with their extensions and commands
@@ -88,5 +89,9 @@ var Languages = map[string]Language{
 			{"g++", "-std=c++20", "-o", "<path>/<name>.run", "<file>"},
 			{"<path>/<name>.run"},
 		},
+	},
+	Swift: {
+		Extension: "swift",
+		Commands:  cmds{{"swift", "<file>"}},
 	},
 }


### PR DESCRIPTION
Add support for [Swift](https://www.swift.org/) language. Tested that it works with common imports (`Foundation`).

### Changes Introduced
- Support for the Swift language
- Adds a missing hline in the example
