### PR TITLE
Add fish support for code blocks

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -10,6 +10,7 @@ Currently supported languages:
 
 * `bash`
 * `zsh`
+* `fish`
 * `elixir`
 * `go`
 * `javascript`
@@ -35,6 +36,14 @@ ls
 ### Zsh
 
 ```zsh
+ls
+```
+
+---
+
+### Fish
+
+```fish
 ls
 ```
 

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -18,6 +18,7 @@ type Language struct {
 const (
 	Bash       = "bash"
 	Zsh        = "zsh"
+	Fish       = "fish"
 	Elixir     = "elixir"
 	Go         = "go"
 	Javascript = "javascript"
@@ -42,6 +43,10 @@ var Languages = map[string]Language{
 	Zsh: {
 		Extension: "zsh",
 		Commands:  cmds{{"zsh", "<file>"}},
+	},
+	Fish: {
+		Extension: "fish",
+		Commands:  cmds{{"fish", "<file>"}},
 	},
 	Elixir: {
 		Extension: "exs",


### PR DESCRIPTION
This PR adds support for [fish (the Friendly Interactive SHell)](https://fishshell.com/) to code blocks  
I followed the example of [this PR](https://github.com/maaslalani/slides/commit/15248d2023f1b77c9139d436a8b1b949f47be75b) about adding support for zsh, but let me know if I missed something!