### PR TITLE
Bind `N` to navigate to previous slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Go to the previous slide with any of the following key sequences:
 * <kbd>p</kbd>
 * <kbd>h</kbd>
 * <kbd>k</kbd>
+* <kbd>N</kbd>
 * <kbd>Page Up</kbd>
 * number + any of the above (go back n slides)
 

--- a/internal/navigation/navigation.go
+++ b/internal/navigation/navigation.go
@@ -57,7 +57,7 @@ func Navigate(state State, keyPress string) State {
 			Page:        navigateNext(state),
 			TotalSlides: state.TotalSlides,
 		}
-	case "up", "k", "left", "h", "p", "pgup":
+	case "up", "k", "left", "h", "p", "pgup", "N":
 		return State{
 			Page:        navigatePrevious(state),
 			TotalSlides: state.TotalSlides,

--- a/internal/navigation/navigation_test.go
+++ b/internal/navigation/navigation_test.go
@@ -25,6 +25,7 @@ func TestNavigation(t *testing.T) {
 		{keys: "3G", target: 2},
 		{keys: "11G", target: 10},
 		{keys: "101G", target: 10},
+		{keys: "nnN", target: 1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add a keybind to navigate to the previous slide when the user presses
`N` (`Shift` + `n`).

This matches what you would intuitively expect when you're using to Vim
keybindings.