### PR TITLE
Fixes maaslalani/slides#231

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -86,6 +86,8 @@ func (m *Model) Load() error {
 		return err
 	}
 
+	content = strings.ReplaceAll(content, "\r", "")
+
 	content = strings.TrimPrefix(content, strings.TrimPrefix(delimiter, "\n"))
 	slides := strings.Split(content, delimiter)
 


### PR DESCRIPTION
Fixes #231 

### Changes Introduced
- Removes carriage returns from the .md file immediately after reading it

I would be skeptical that the solution is this simple, but I have verified that it works on both Windows and Linux (WSL Ubuntu) using slides.md as well as the two files attached in the issue (one with DOS line endings and the other with Unix line endings). 🤷🏽‍♂️
