### PR TITLE
Powershell code execution

### DIFF
--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -85,7 +85,6 @@ func Execute(code Block) Result {
 		}
 	}
 
-	defer f.Close()
 	defer os.Remove(f.Name())
 
 	_, err = f.WriteString(code.Code)
@@ -95,6 +94,9 @@ func Execute(code Block) Result {
 			ExitCode: ExitCodeInternalError,
 		}
 	}
+
+	// Close the file now so platforms like Windows can access it.
+	f.Close()
 
 	var (
 		output   strings.Builder

--- a/internal/code/code_test.go
+++ b/internal/code/code_test.go
@@ -112,6 +112,19 @@ fmt.Println("Hello, world!")
 				},
 			},
 		},
+		{
+			markdown: `
+~~~powershell
+Write-Host "Hello, World!"
+~~~
+`,
+			expected: []code.Block{
+				{
+					Code:     `Write-Host "Hello, World!"`,
+					Language: "powershell",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/internal/code/execute_test.go
+++ b/internal/code/execute_test.go
@@ -63,6 +63,17 @@ func TestExecute(t *testing.T) {
 				},
 			},
 		)
+	} else if runtime.GOOS == "windows" {
+		tt = append(tt, TestCase{
+			block: code.Block{
+				Code:     `Write-Host "Hello, powershell!"`,
+				Language: "powershell",
+			},
+			expected: code.Result{
+				Out:      "Hello, powershell!\n",
+				ExitCode: 0,
+			},
+		})
 	}
 
 	for _, tc := range tt {

--- a/internal/code/execute_test.go
+++ b/internal/code/execute_test.go
@@ -1,54 +1,19 @@
 package code_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/maaslalani/slides/internal/code"
 )
 
-func TestExecute(t *testing.T) {
-	tt := []struct {
-		block    code.Block
-		expected code.Result
-	}{
-		{
-			block: code.Block{
-				Code: `
-package main
-
-import "fmt"
-
-func main() {
-  fmt.Print("Hello, go!")
+type TestCase struct {
+	block    code.Block
+	expected code.Result
 }
-        `,
-				Language: "go",
-			},
-			expected: code.Result{
-				Out:      "Hello, go!",
-				ExitCode: 0,
-			},
-		},
-		{
-			block: code.Block{
-				Code:     `echo "Hello, bash!"`,
-				Language: "bash",
-			},
-			expected: code.Result{
-				Out:      "Hello, bash!\n",
-				ExitCode: 0,
-			},
-		},
-		{
-			block: code.Block{
-				Code:     `Invalid Code`,
-				Language: "bash",
-			},
-			expected: code.Result{
-				Out:      "exit status 127",
-				ExitCode: 127,
-			},
-		},
+
+func TestExecute(t *testing.T) {
+	tt := []TestCase{
 		{
 			block: code.Block{
 				Code:     `Invalid Code`,
@@ -59,6 +24,45 @@ func main() {
 				ExitCode: code.ExitCodeInternalError,
 			},
 		},
+	}
+
+	if runtime.GOOS == "linux" {
+		tt = append(tt, TestCase{
+			block: code.Block{
+				Code: `
+	package main
+
+	import "fmt"
+
+	func main() {
+	  fmt.Print("Hello, go!")
+	}
+			`,
+				Language: "go",
+			},
+			expected: code.Result{
+				Out:      "Hello, go!",
+				ExitCode: 0,
+			}},
+			TestCase{block: code.Block{
+				Code:     `echo "Hello, bash!"`,
+				Language: "bash",
+			},
+				expected: code.Result{
+					Out:      "Hello, bash!\n",
+					ExitCode: 0,
+				}},
+			TestCase{
+				block: code.Block{
+					Code:     `Invalid Code`,
+					Language: "bash",
+				},
+				expected: code.Result{
+					Out:      "exit status 127",
+					ExitCode: 127,
+				},
+			},
+		)
 	}
 
 	for _, tc := range tt {

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -19,6 +19,7 @@ const (
 	Bash       = "bash"
 	Zsh        = "zsh"
 	Fish       = "fish"
+	Powershell = "powershell"
 	Elixir     = "elixir"
 	Go         = "go"
 	Javascript = "javascript"
@@ -49,6 +50,10 @@ var Languages = map[string]Language{
 	Fish: {
 		Extension: "fish",
 		Commands:  cmds{{"fish", "<file>"}},
+	},
+	Powershell: {
+		Extension: "ps1",
+		Commands:  cmds{{"powershell", "-File", "<file>"}},
 	},
 	Elixir: {
 		Extension: "exs",


### PR DESCRIPTION
Fixes #229, partially? I didn't look at Command Prompt.

### Changes Introduced
- Allows `ctrl+e` to execute PowerShell code blocks
  - This required closing the temporary file immediately instead of deferring because `slides` blocks Windows from accessing the file
- Test changes to support `make test` on different OS platforms

