### PR TITLE
Enable Markdown processing in "details" block

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Slides in your terminal.
 [![Snapcraft](https://snapcraft.io/slides/badge.svg)](https://snapcraft.io/slides)
 [![AUR](https://img.shields.io/aur/version/slides?label=AUR)](https://aur.archlinux.org/packages/slides)
 
-<details>
+<details markdown="block">
 <summary>Instructions</summary>
 
 #### MacOS


### PR DESCRIPTION
The default Markdown processor for GitHub Pages doesn't process the contents of `<details>` blocks, resulting in raw Markdown in the output at https://maaslalani.com/slides/:

![image](https://github.com/maaslalani/slides/assets/8521043/29b8c041-6b7e-41a1-b866-ab2dd08652aa)

This PR instructs Kramdown to process Markdown in that block:

![image](https://github.com/maaslalani/slides/assets/8521043/34a282fe-b4dc-42be-ab1b-3375eafd26da)

