### PR TITLE
Add presenterm as an alternative tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ own computer without needing to download `slides` and the presentation file.
 * [`lookatme`](https://github.com/d0c-s4vage/lookatme)
 * [`sli.dev`](https://sli.dev/)
 * [`sent`](https://tools.suckless.org/sent/)
+* [`presenterm`](https://github.com/mfontanini/presenterm)
 
 ### Development
 See the [development documentation](./docs/development)


### PR DESCRIPTION
This adds _presenterm_ as an alternative tool, as suggested by [@maaslalani](https://github.com/maaslalani/slides/issues/2#issuecomment-1752149352).