### PR TITLE
Pre commands inherit stderr from main process

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -3,6 +3,7 @@ package process
 import (
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -51,6 +52,7 @@ func Parse(markdown string) []Block {
 func (b *Block) Execute() {
 	c := strings.Split(b.Command, " ")
 	cmd := exec.Command(c[0], c[1:]...)
+	cmd.Stderr = os.Stderr;
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return


### PR DESCRIPTION
This has two main benefits:

1) Errors during preprocessing are now visible (not on the slides
   themselves but back on the console after exiting), which helps with
   debugging.
2) Subprocesses are able to do fine-grained formatting, as terminfo
   commands now work properly. For example, `tput cols` and `tput lines`
   now return the correct terminal size instead of the defalt 80x24.