### PR TITLE
add scala support using scala-cli

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -180,3 +180,15 @@ void main() {
 ```v
 println('Hello, world!')
 ```
+
+---
+
+### Scala
+
+```scala
+//> using dep com.lihaoyi::pprint:0.8.1
+
+object Main extends App {
+  println("Hello")
+}
+```

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -34,6 +34,7 @@ const (
 	Swift      = "swift"
 	Dart       = "dart"
 	V          = "v"
+  Scala      = "scala"
 )
 
 // Languages is a map of supported languages with their extensions and commands
@@ -119,4 +120,8 @@ var Languages = map[string]Language{
 		Extension: "v",
 		Commands:  cmds{{"v", "run", "<file>"}},
 	},
+  Scala: {
+    Extension: "sc",
+    Commands: cmds{{"scala-cli", "run", "<file>"}},
+  },
 }


### PR DESCRIPTION
Hi, very nice tool!

I was missing support for scala, so I've added a super simple implementation using scala-cli which will become the standard scala runner in scala version 3.5 really soon, so should be installed for most users

### Changes Introduced
- added command to run scala code blocks using the `sc` filetype with scala-cli
- added example in `examples/code_blocks.md`
