### PR TITLE
Added support for C# using dotnet CLI with dotnet script

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -23,6 +23,7 @@ Currently supported languages:
 * `swift`
 * `dart`
 * `v`
+* `csharp`
 <!-- * `secret` -->
 
 ---
@@ -191,4 +192,12 @@ println('Hello, world!')
 object Main extends App {
   println("Hello")
 }
+```
+
+---
+
+### C#
+
+```csharp
+Console.WriteLine("Hello, world!");
 ```

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -36,6 +36,7 @@ const (
 	V          = "v"
 	Scala      = "scala"
 	Haskell    = "haskell"
+	CSharp     = "csharp"
 )
 
 // Languages is a map of supported languages with their extensions and commands
@@ -128,5 +129,9 @@ var Languages = map[string]Language{
 	Haskell: {
 		Extension: "hs",
 		Commands: cmds{{"runghc", "<file>"}},
+	},
+	CSharp: {
+		Extension: "csx",
+		Commands: cmds{{"dotnet", "script", "<file>"}},
 	},
 }


### PR DESCRIPTION
Fixes #...

### Changes Introduced
- Added support for running C# snippets inline using the [`dotnet` CLI](https://github.com/dotnet/cli) and the [`dotnet-script`](https://github.com/dotnet-script/dotnet-script) tool