### PR TITLE
feat: add nushell support

### DIFF
--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -192,3 +192,11 @@ object Main extends App {
   println("Hello")
 }
 ```
+
+---
+
+## Nushell
+
+```nu
+{message: "Hello, World!"} | get message
+```

--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -23,7 +23,7 @@ Currently supported languages:
 * `swift`
 * `dart`
 * `v`
-* `nushell`
+* `nu`
 <!-- * `secret` -->
 
 ---

--- a/examples/code_blocks.md
+++ b/examples/code_blocks.md
@@ -23,6 +23,7 @@ Currently supported languages:
 * `swift`
 * `dart`
 * `v`
+* `nushell`
 <!-- * `secret` -->
 
 ---
@@ -198,5 +199,16 @@ object Main extends App {
 ## Nushell
 
 ```nu
-{message: "Hello, World!"} | get message
+# Basic string output
+echo "Hello from Nushell!"
+```
+
+```nu
+# Data manipulation with pipelines
+[1, 2, 3, 4, 5] | where $it > 2 | math sum
+```
+
+```nu
+# Working with records
+{name: "Alice", age: 30, city: "New York"} | get name
 ```

--- a/internal/code/execute_test.go
+++ b/internal/code/execute_test.go
@@ -51,6 +51,26 @@ func main() {
 		},
 		{
 			block: code.Block{
+				Code:     `echo "Hello, nushell!"`,
+				Language: "nu",
+			},
+			expected: code.Result{
+				Out:      "Hello, nushell!\n",
+				ExitCode: 0,
+			},
+		},
+		{
+			block: code.Block{
+				Code:     `{message: "Hello, World!"} | get message`,
+				Language: "nu",
+			},
+			expected: code.Result{
+				Out:      "Hello, World!\n",
+				ExitCode: 0,
+			},
+		},
+		{
+			block: code.Block{
 				Code:     `Invalid Code`,
 				Language: "invalid",
 			},

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -36,6 +36,7 @@ const (
 	V          = "v"
 	Scala      = "scala"
 	Haskell    = "haskell"
+	Nushell    = "nu"
 )
 
 // Languages is a map of supported languages with their extensions and commands
@@ -128,5 +129,9 @@ var Languages = map[string]Language{
 	Haskell: {
 		Extension: "hs",
 		Commands: cmds{{"runghc", "<file>"}},
+	},
+	Nushell: {
+		Extension: "nu",
+		Commands:  cmds{{"nu", "<file>"}},
 	},
 }

--- a/internal/code/languages.go
+++ b/internal/code/languages.go
@@ -132,6 +132,6 @@ var Languages = map[string]Language{
 	},
 	Nushell: {
 		Extension: "nu",
-		Commands:  cmds{{"nu", "<file>"}},
+		Commands:  cmds{{"nu", "--no-config-file", "<file>"}},
 	},
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -20,6 +20,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/maaslalani/slides/internal/code"
 	"github.com/maaslalani/slides/internal/meta"
+	"github.com/maaslalani/slides/internal/syntax"
 	"github.com/maaslalani/slides/styles"
 )
 
@@ -207,6 +208,7 @@ func (m Model) View() string {
 	r, _ := glamour.NewTermRenderer(m.Theme, glamour.WithWordWrap(m.viewport.Width))
 	slide := m.Slides[m.Page]
 	slide = code.HideComments(slide)
+	slide = syntax.PreprocessNushellMarkdown(slide)
 	slide, err := r.Render(slide)
 	slide = strings.ReplaceAll(slide, "\t", tabSpaces)
 	slide += m.VirtualText

--- a/internal/syntax/nushell.go
+++ b/internal/syntax/nushell.go
@@ -99,8 +99,7 @@ func (n *NushellHighlighter) ShouldUsePreprocessing(code string) bool {
 
 // LanguageMapping defines fallback mappings for nushell identifiers
 var LanguageMapping = map[string]string{
-	"nu":      "bash",
-	"nushell": "bash",
+	"nu": "bash",
 }
 
 // GetMappedLanguage returns the mapped language for highlighting,
@@ -114,7 +113,7 @@ func GetMappedLanguage(lang string) string {
 
 // ProcessNushellCode applies preprocessing if needed and returns the language to use
 func ProcessNushellCode(code, language string) (processedCode, highlightLanguage string) {
-	if language == "nu" || language == "nushell" {
+	if language == "nu" {
 		highlighter := NewNushellHighlighter()
 
 		if highlighter.ShouldUsePreprocessing(code) {
@@ -132,7 +131,7 @@ func ProcessNushellCode(code, language string) (processedCode, highlightLanguage
 func PreprocessNushellMarkdown(markdown string) string {
 	// Regular expression to match code blocks with nushell language identifiers
 	// Matches both ```nu and ```nushell
-	nushellCodeBlockRegex := regexp.MustCompile(`(?m)^` + "```(?:nu|nushell)" + `$`)
+	nushellCodeBlockRegex := regexp.MustCompile(`(?m)^` + "```(?:nu)" + `$`)
 
 	// Replace nushell identifiers with bash for better syntax highlighting
 	processed := nushellCodeBlockRegex.ReplaceAllString(markdown, "```bash")

--- a/internal/syntax/nushell.go
+++ b/internal/syntax/nushell.go
@@ -1,0 +1,141 @@
+package syntax
+
+import (
+	"regexp"
+	"strings"
+)
+
+// NushellHighlighter provides basic syntax highlighting for Nushell code
+// by converting it to a format that works better with existing shell lexers
+type NushellHighlighter struct{}
+
+// NewNushellHighlighter creates a new nushell highlighter
+func NewNushellHighlighter() *NushellHighlighter {
+	return &NushellHighlighter{}
+}
+
+// PreprocessForShellHighlighting converts nushell syntax to be more compatible
+// with shell syntax highlighters like bash
+func (n *NushellHighlighter) PreprocessForShellHighlighting(code string) string {
+	// Apply various transformations to make nushell code more shell-like
+	// for better syntax highlighting
+
+	processed := code
+
+	// Convert nushell pipes to regular pipes (already compatible)
+	// No change needed for basic pipes
+
+	// Convert nushell comments (# already compatible with shell)
+	// No change needed
+
+	// Convert nushell variables ($var -> $var, already compatible)
+	// No change needed for basic variables
+
+	// Convert nushell record syntax {key: value} to something more shell-like
+	// This is a basic approximation for highlighting purposes
+	recordRegex := regexp.MustCompile(`\{([^}]+)\}`)
+	processed = recordRegex.ReplaceAllStringFunc(processed, func(match string) string {
+		// Keep the braces but make it look more like shell arrays
+		return strings.ReplaceAll(match, ":", "=")
+	})
+
+	// Convert nushell list syntax [item1, item2] to shell-like arrays
+	listRegex := regexp.MustCompile(`\[([^\]]+)\]`)
+	processed = listRegex.ReplaceAllString(processed, "($1)")
+
+	// Convert nushell where clauses to look more like shell conditionals
+	whereRegex := regexp.MustCompile(`\|\s*where\s+`)
+	processed = whereRegex.ReplaceAllString(processed, "| grep ")
+
+	// Convert nushell $it references to shell-like variables
+	processed = strings.ReplaceAll(processed, "$it", "$_")
+
+	return processed
+}
+
+// GetFallbackLanguage returns the best fallback language for nushell highlighting
+func (n *NushellHighlighter) GetFallbackLanguage() string {
+	return "bash"
+}
+
+// ShouldUsePreprocessing determines if the code should be preprocessed
+// based on common nushell patterns
+func (n *NushellHighlighter) ShouldUsePreprocessing(code string) bool {
+	nushellPatterns := []string{
+		"{",           // Records
+		"where $it",   // Nushell where clauses
+		"| get ",      // Nushell get command
+		"| select ",   // Nushell select command
+		"| each ",     // Nushell each command
+		"| from ",     // Nushell from command
+		"| to ",       // Nushell to command
+		"| str ",      // Nushell str command
+		"| math ",     // Nushell math command
+		"| length",    // Nushell length command
+		"| first",     // Nushell first command
+		"| last",      // Nushell last command
+		"| sort-by",   // Nushell sort-by command
+		"| group-by",  // Nushell group-by command
+		"| where ",    // Nushell where command
+		"| into ",     // Nushell into command
+		"| append",    // Nushell append command
+		"| prepend",   // Nushell prepend command
+		"open ",       // Nushell open command
+		"save ",       // Nushell save command
+		"sys",         // Nushell sys command
+		"date now",    // Nushell date command
+		"http get",    // Nushell http command
+		"format date", // Nushell format command
+	}
+
+	for _, pattern := range nushellPatterns {
+		if strings.Contains(code, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// LanguageMapping defines fallback mappings for nushell identifiers
+var LanguageMapping = map[string]string{
+	"nu":      "bash",
+	"nushell": "bash",
+}
+
+// GetMappedLanguage returns the mapped language for highlighting,
+// or the original if no mapping exists
+func GetMappedLanguage(lang string) string {
+	if mapped, exists := LanguageMapping[lang]; exists {
+		return mapped
+	}
+	return lang
+}
+
+// ProcessNushellCode applies preprocessing if needed and returns the language to use
+func ProcessNushellCode(code, language string) (processedCode, highlightLanguage string) {
+	if language == "nu" || language == "nushell" {
+		highlighter := NewNushellHighlighter()
+
+		if highlighter.ShouldUsePreprocessing(code) {
+			return highlighter.PreprocessForShellHighlighting(code), highlighter.GetFallbackLanguage()
+		}
+
+		return code, highlighter.GetFallbackLanguage()
+	}
+
+	return code, language
+}
+
+// PreprocessNushellMarkdown preprocesses markdown to replace nushell language identifiers
+// with bash for better syntax highlighting in code blocks
+func PreprocessNushellMarkdown(markdown string) string {
+	// Regular expression to match code blocks with nushell language identifiers
+	// Matches both ```nu and ```nushell
+	nushellCodeBlockRegex := regexp.MustCompile(`(?m)^` + "```(?:nu|nushell)" + `$`)
+
+	// Replace nushell identifiers with bash for better syntax highlighting
+	processed := nushellCodeBlockRegex.ReplaceAllString(markdown, "```bash")
+
+	return processed
+}

--- a/internal/syntax/nushell_test.go
+++ b/internal/syntax/nushell_test.go
@@ -28,20 +28,7 @@ echo "Hello from Nushell!"
 Some other content.`,
 		},
 		{
-			name: "Replace nushell language identifier",
-			input: `# Test Slide
-
-` + "```nushell" + `
-[1, 2, 3] | where $it > 1
-` + "```" + ``,
-			expected: `# Test Slide
-
-` + "```bash" + `
-[1, 2, 3] | where $it > 1
-` + "```" + ``,
-		},
-		{
-			name: "Multiple nushell code blocks",
+			name: "Multiple nu code blocks",
 			input: `# Slide 1
 
 ` + "```nu" + `
@@ -52,7 +39,7 @@ echo "First block"
 
 # Slide 2
 
-` + "```nushell" + `
+` + "```nu" + `
 echo "Second block"
 ` + "```" + ``,
 			expected: `# Slide 1
@@ -256,13 +243,8 @@ func TestGetMappedLanguage(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Map nu to bash",
+			name:     "Map nu (alternative test)",
 			language: "nu",
-			expected: "bash",
-		},
-		{
-			name:     "Map nushell to bash",
-			language: "nushell",
 			expected: "bash",
 		},
 		{
@@ -305,13 +287,6 @@ func TestProcessNushellCode(t *testing.T) {
 			code:             `{name: "Alice"} | get name`,
 			language:         "nu",
 			expectedCode:     `{name= "Alice"} | get name`,
-			expectedLanguage: "bash",
-		},
-		{
-			name:             "Process nushell code with nushell identifier",
-			code:             `[1, 2, 3] | where $it > 1`,
-			language:         "nushell",
-			expectedCode:     `(1, 2, 3) | grep $_ > 1`,
 			expectedLanguage: "bash",
 		},
 		{

--- a/internal/syntax/nushell_test.go
+++ b/internal/syntax/nushell_test.go
@@ -1,0 +1,364 @@
+package syntax
+
+import (
+	"testing"
+)
+
+func TestPreprocessNushellMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "Replace nu language identifier",
+			input: `# Test Slide
+
+` + "```nu" + `
+echo "Hello from Nushell!"
+` + "```" + `
+
+Some other content.`,
+			expected: `# Test Slide
+
+` + "```bash" + `
+echo "Hello from Nushell!"
+` + "```" + `
+
+Some other content.`,
+		},
+		{
+			name: "Replace nushell language identifier",
+			input: `# Test Slide
+
+` + "```nushell" + `
+[1, 2, 3] | where $it > 1
+` + "```" + ``,
+			expected: `# Test Slide
+
+` + "```bash" + `
+[1, 2, 3] | where $it > 1
+` + "```" + ``,
+		},
+		{
+			name: "Multiple nushell code blocks",
+			input: `# Slide 1
+
+` + "```nu" + `
+echo "First block"
+` + "```" + `
+
+---
+
+# Slide 2
+
+` + "```nushell" + `
+echo "Second block"
+` + "```" + ``,
+			expected: `# Slide 1
+
+` + "```bash" + `
+echo "First block"
+` + "```" + `
+
+---
+
+# Slide 2
+
+` + "```bash" + `
+echo "Second block"
+` + "```" + ``,
+		},
+		{
+			name: "Leave other languages unchanged",
+			input: `# Mixed Languages
+
+` + "```python" + `
+print("Hello Python")
+` + "```" + `
+
+` + "```nu" + `
+echo "Hello Nushell"
+` + "```" + `
+
+` + "```go" + `
+fmt.Println("Hello Go")
+` + "```" + ``,
+			expected: `# Mixed Languages
+
+` + "```python" + `
+print("Hello Python")
+` + "```" + `
+
+` + "```bash" + `
+echo "Hello Nushell"
+` + "```" + `
+
+` + "```go" + `
+fmt.Println("Hello Go")
+` + "```" + ``,
+		},
+		{
+			name:     "No code blocks",
+			input:    "# Just a title\n\nSome regular markdown content.",
+			expected: "# Just a title\n\nSome regular markdown content.",
+		},
+		{
+			name:     "Empty input",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PreprocessNushellMarkdown(tt.input)
+			if result != tt.expected {
+				t.Errorf("PreprocessNushellMarkdown() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNushellHighlighterPreprocessForShellHighlighting(t *testing.T) {
+	highlighter := NewNushellHighlighter()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Convert records to shell-like syntax",
+			input:    `{name: "Alice", age: 30}`,
+			expected: `{name= "Alice", age= 30}`,
+		},
+		{
+			name:     "Convert lists to shell arrays",
+			input:    `[1, 2, 3, 4, 5]`,
+			expected: `(1, 2, 3, 4, 5)`,
+		},
+		{
+			name:     "Convert where clauses",
+			input:    `ls | where size > 100`,
+			expected: `ls | grep size > 100`,
+		},
+		{
+			name:     "Convert $it references",
+			input:    `[1, 2, 3] | where $it > 1`,
+			expected: `(1, 2, 3) | grep $_ > 1`,
+		},
+		{
+			name: "Complex nushell pipeline",
+			input: `{users: [{name: "John", age: 25}, {name: "Jane", age: 30}]}
+| get users
+| where $it.age > 26`,
+			expected: `{users= ({name= "John", age= 25}, {name= "Jane", age= 30})}
+| get users
+| grep $_.age > 26`,
+		},
+		{
+			name:     "No nushell syntax",
+			input:    `echo "Hello World"`,
+			expected: `echo "Hello World"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := highlighter.PreprocessForShellHighlighting(tt.input)
+			if result != tt.expected {
+				t.Errorf("PreprocessForShellHighlighting() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldUsePreprocessing(t *testing.T) {
+	highlighter := NewNushellHighlighter()
+
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{
+			name:     "Contains nushell record syntax",
+			code:     `{name: "Alice"}`,
+			expected: true,
+		},
+		{
+			name:     "Contains where $it",
+			code:     `[1, 2, 3] | where $it > 1`,
+			expected: true,
+		},
+		{
+			name:     "Contains nushell get command",
+			code:     `data | get name`,
+			expected: true,
+		},
+		{
+			name:     "Contains nushell select command",
+			code:     `data | select name age`,
+			expected: true,
+		},
+		{
+			name:     "Contains nushell math command",
+			code:     `[1, 2, 3] | math sum`,
+			expected: true,
+		},
+		{
+			name:     "Contains nushell date command",
+			code:     `date now`,
+			expected: true,
+		},
+		{
+			name:     "Contains nushell http command",
+			code:     `http get https://api.example.com`,
+			expected: true,
+		},
+		{
+			name:     "Contains sys command",
+			code:     `sys`,
+			expected: true,
+		},
+		{
+			name:     "Basic shell command",
+			code:     `echo "Hello World"`,
+			expected: false,
+		},
+		{
+			name:     "Regular bash syntax",
+			code:     `ls -la | grep ".txt"`,
+			expected: false,
+		},
+		{
+			name:     "Empty code",
+			code:     ``,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := highlighter.ShouldUsePreprocessing(tt.code)
+			if result != tt.expected {
+				t.Errorf("ShouldUsePreprocessing() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetMappedLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		expected string
+	}{
+		{
+			name:     "Map nu to bash",
+			language: "nu",
+			expected: "bash",
+		},
+		{
+			name:     "Map nushell to bash",
+			language: "nushell",
+			expected: "bash",
+		},
+		{
+			name:     "Leave other languages unchanged",
+			language: "python",
+			expected: "python",
+		},
+		{
+			name:     "Leave go unchanged",
+			language: "go",
+			expected: "go",
+		},
+		{
+			name:     "Leave empty string unchanged",
+			language: "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetMappedLanguage(tt.language)
+			if result != tt.expected {
+				t.Errorf("GetMappedLanguage() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProcessNushellCode(t *testing.T) {
+	tests := []struct {
+		name             string
+		code             string
+		language         string
+		expectedCode     string
+		expectedLanguage string
+	}{
+		{
+			name:             "Process nushell code with nu identifier",
+			code:             `{name: "Alice"} | get name`,
+			language:         "nu",
+			expectedCode:     `{name= "Alice"} | get name`,
+			expectedLanguage: "bash",
+		},
+		{
+			name:             "Process nushell code with nushell identifier",
+			code:             `[1, 2, 3] | where $it > 1`,
+			language:         "nushell",
+			expectedCode:     `(1, 2, 3) | grep $_ > 1`,
+			expectedLanguage: "bash",
+		},
+		{
+			name:             "Simple nushell code without preprocessing",
+			code:             `echo "Hello World"`,
+			language:         "nu",
+			expectedCode:     `echo "Hello World"`,
+			expectedLanguage: "bash",
+		},
+		{
+			name:             "Non-nushell language unchanged",
+			code:             `print("Hello Python")`,
+			language:         "python",
+			expectedCode:     `print("Hello Python")`,
+			expectedLanguage: "python",
+		},
+		{
+			name:             "Go code unchanged",
+			code:             `fmt.Println("Hello Go")`,
+			language:         "go",
+			expectedCode:     `fmt.Println("Hello Go")`,
+			expectedLanguage: "go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processedCode, highlightLanguage := ProcessNushellCode(tt.code, tt.language)
+
+			if processedCode != tt.expectedCode {
+				t.Errorf("ProcessNushellCode() code = %q, want %q", processedCode, tt.expectedCode)
+			}
+
+			if highlightLanguage != tt.expectedLanguage {
+				t.Errorf("ProcessNushellCode() language = %q, want %q", highlightLanguage, tt.expectedLanguage)
+			}
+		})
+	}
+}
+
+func TestGetFallbackLanguage(t *testing.T) {
+	highlighter := NewNushellHighlighter()
+
+	expected := "bash"
+	result := highlighter.GetFallbackLanguage()
+
+	if result != expected {
+		t.Errorf("GetFallbackLanguage() = %q, want %q", result, expected)
+	}
+}


### PR DESCRIPTION
I love this tool! I added a small modification to support my favourite shell, [`nushell`](https://www.nushell.sh/), a new kind of shell where everything is structured data.

After some polishing and adding tests, I thought it was time to contribute my changes back.

Thank you so much for creating this great tool, @maaslalani! 🙏 
I hope my contribution is up to your standards. Please let me know if I should change anything.

## Summary

- Added nushell language support for syntax highlighting in slides
- Added nushell support for .nu file extension mapping with `nu` command
- Follows the same pattern as recent language additions (Haskell https://github.com/maaslalani/slides/pull/299, Scala https://github.com/maaslalani/slides/pull/298)

<img width="2168" height="1238" alt="slides with nushell" src="https://github.com/user-attachments/assets/db6f0b6e-5848-4a41-a6b6-0c33d12db230" />


## Code Structure
```
slides/
├── internal/
│   ├── code/
│   │   ├── languages.go          # Enhanced with nushell support
│   │   ├── execute_test.go        # Added nushell execution tests
│   └── syntax/                   # New module for syntax highlighting
│       ├── nushell.go            # Nushell highlighting logic
│       └── nushell_test.go       # Comprehensive test suite
└── examples/
    └── code_blocks.md            # Enhanced nushell examples
```

## 🎨 How Syntax Highlighting Works

### The Problem
- Chroma (used by Glamour) doesn't natively support nushell syntax highlighting
- Code blocks with `nu` identifiers showed as plain text

### The Solution
1. **Preprocessing**: Before markdown is rendered, replace ````nu` with ````bash`
2. **Fallback**: Bash syntax highlighting provides reasonable highlighting for most nushell syntax
3. **Future-Proof**: System ready for native nushell support when available in Chroma

### Code Flow
```
Markdown Input → Syntax Preprocessing → Glamour/Chroma → Highlighted Output
     ↓                    ↓                   ↓              ↓
```nu          →      ```bash        →    Chroma      →   Highlighted
echo "hi"              echo "hi"           Lexer           Code Block
```              ```              
```

## Testing

- [x] Built and tested locally with `make test`
- [x] Verified compilation with `make build`
- [x] Test with actual nushell code blocks in markdown presentations
- [x] Added nushell syntax highlighting

```shell
make test
go test ./... -short
?   	github.com/maaslalani/slides	[no test files]
?   	github.com/maaslalani/slides/internal/cmd	[no test files]
?   	github.com/maaslalani/slides/internal/model	[no test files]
?   	github.com/maaslalani/slides/internal/server	[no test files]
ok  	github.com/maaslalani/slides/internal/code	0.752s
ok  	github.com/maaslalani/slides/internal/file	(cached)
ok  	github.com/maaslalani/slides/internal/meta	(cached)
ok  	github.com/maaslalani/slides/internal/navigation	(cached)
ok  	github.com/maaslalani/slides/internal/process	(cached)
ok  	github.com/maaslalani/slides/internal/syntax	0.552s
ok  	github.com/maaslalani/slides/styles	(cached)
``` 

🤖 Created with the help of `Claude Sonnet 4`