### PR TITLE
feat: add paused slide support

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,15 @@ paging: Slide %d / %d
   view. Defaults to the OS current user's full name. Can be empty to hide the author.
 * `date`: A `string` that is used to format today's date in the `YYYY-MM-DD` format. If the date is not a valid
   format, the string will be displayed. Defaults to `YYYY-MM-DD`.
-* `paging`: A `string` that contains 0 or more `%d` directives. The first `%d`
-  will be replaced with the current slide number and the second `%d` will be
-  replaced with the total slides count. Defaults to `Slide %d / %d`.
+* `paging`: A `string` that contains 0 or more `%d` directives. The directives
+  are replaced in order: slide number, total slides, current part (if paused), total parts (if paused).
+  Examples:
+  - `Slide %d` (1 directive): current slide number
+  - `Slide %d / %d` (2 directives): current slide / total slides (default)
+  - `Slide %d / %d | Part %d` (3 directives): current slide / total slides | current part
+  - `Slide %d / %d (Part %d / %d)` (4 directives): current slide / total slides (current part / total parts)
+  
+  Defaults to `Slide %d / %d`.
   You will need to surround the paging value with quotes if it starts with `%`.
 
 #### Date format

--- a/examples/paused_slides.md
+++ b/examples/paused_slides.md
@@ -1,0 +1,40 @@
+---
+paging: Slide %d / %d (Part %d / %d)
+---
+
+# Paused Slides Example
+
+This is the first part of the slide.
+
++++
+
+You can use the `+++` delimiter to pause a slide.
+
++++
+
+When you press the next key (space, j, l, right arrow, etc),
+you'll see the next pause, not the next slide.
+
++++
+
+This allows you to reveal content step-by-step.
+
+---
+
+# Second Slide (No Pauses)
+
+This slide has no pauses, so next key will jump to the next slide.
+
+---
+
+# Third Slide with Steps
+
+Step 1: Introduction
+
++++
+
+Step 2: Details
+
++++
+
+Step 3: Conclusion

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -268,13 +268,20 @@ func (m Model) View() string {
 }
 
 func (m *Model) paging() string {
-	switch strings.Count(m.Paging, "%d") {
-	case 2:
-		return fmt.Sprintf(m.Paging, m.Page+1, len(m.Slides))
+	count := strings.Count(m.Paging, "%d")
+	switch count {
+	case 0:
+		return m.Paging
 	case 1:
 		return fmt.Sprintf(m.Paging, m.Page+1)
+	case 2:
+		return fmt.Sprintf(m.Paging, m.Page+1, len(m.Slides))
+	case 3:
+		return fmt.Sprintf(m.Paging, m.Page+1, len(m.Slides), m.Part+1)
 	default:
-		return m.Paging
+		// 4 or more: slide, totalSlides, part, totalParts
+		totalParts := m.stepsInSlide(m.Page)
+		return fmt.Sprintf(m.Paging, m.Page+1, len(m.Slides), m.Part+1, totalParts)
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,14 +31,16 @@ var (
 )
 
 const (
-	delimiter = "\n---\n"
+	delimiter       = "\n---\n"
+	pausedDelimiter = "\n+++\n"
 )
 
 // Model represents the model of this presentation, which contains all the
 // state related to the current slides.
 type Model struct {
-	Slides   []string
+	Slides   []Slide
 	Page     int
+	Part     int
 	Author   string
 	Date     string
 	Theme    glamour.TermRendererOption
@@ -49,6 +52,11 @@ type Model struct {
 	// original slides, it will be displayed on a slide and reset on page change
 	VirtualText string
 	Search      navigation.Search
+}
+
+// Slide represents a logical slide with optional paused parts.
+type Slide struct {
+	Parts []string
 }
 
 type fileWatchMsg struct{}
@@ -98,13 +106,14 @@ func (m *Model) Load() error {
 		slides = slides[1:]
 	}
 
-	m.Slides = slides
+	m.Slides = splitSlides(slides)
 	m.Author = metaData.Author
 	m.Date = metaData.Date
 	m.Paging = metaData.Paging
 	if m.Theme == nil {
 		m.Theme = styles.SelectTheme(metaData.Theme)
 	}
+	m.clampPosition()
 
 	return nil
 }
@@ -154,7 +163,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Search.Execute(&m)
 		case "ctrl+e":
 			// Run code blocks
-			blocks, err := code.Parse(m.Slides[m.Page])
+			blocks, err := code.Parse(m.currentSlideContent())
 			if err != nil {
 				// We couldn't parse the code block on the screen
 				m.VirtualText = "\n" + err.Error()
@@ -167,7 +176,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.VirtualText = strings.Join(outs, "\n")
 		case "y":
-			blocks, err := code.Parse(m.Slides[m.Page])
+			blocks, err := code.Parse(m.currentSlideContent())
 			if err != nil {
 				return m, nil
 			}
@@ -177,6 +186,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "ctrl+c", "q":
 			return m, tea.Quit
+		case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+			m.buffer = updateRepeatBuffer(m.buffer, keyPress)
+			return m, nil
+		case " ", "down", "j", "right", "l", "enter", "n", "pgdown":
+			repeat := m.consumeRepeat()
+			m.advanceSteps(repeat)
+			return m, nil
+		case "up", "k", "left", "h", "p", "pgup", "N":
+			repeat := m.consumeRepeat()
+			m.retreatSteps(repeat)
+			return m, nil
+		case "g":
+			newState := navigation.Navigate(navigation.State{
+				Buffer:      m.buffer,
+				Page:        m.Page,
+				TotalSlides: len(m.Slides),
+			}, keyPress)
+			m.buffer = newState.Buffer
+			if newState.Page != m.Page {
+				m.SetPageAndPart(newState.Page, 0)
+			}
+			return m, nil
+		case "G":
+			newState := navigation.Navigate(navigation.State{
+				Buffer:      m.buffer,
+				Page:        m.Page,
+				TotalSlides: len(m.Slides),
+			}, keyPress)
+			m.buffer = newState.Buffer
+			m.SetPageAndPart(newState.Page, 0)
+			return m, nil
 		default:
 			newState := navigation.Navigate(navigation.State{
 				Buffer:      m.buffer,
@@ -184,7 +224,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				TotalSlides: len(m.Slides),
 			}, keyPress)
 			m.buffer = newState.Buffer
-			m.SetPage(newState.Page)
+			m.SetPageAndPart(newState.Page, 0)
 		}
 
 	case fileWatchMsg:
@@ -192,9 +232,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err == nil && newFileInfo.ModTime() != fileInfo.ModTime() {
 			fileInfo = newFileInfo
 			_ = m.Load()
-			if m.Page >= len(m.Slides) {
-				m.Page = len(m.Slides) - 1
-			}
+			m.clampPosition()
 		}
 		return m, fileWatchCmd()
 	}
@@ -205,7 +243,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // contains the author, date, and pagination information.
 func (m Model) View() string {
 	r, _ := glamour.NewTermRenderer(m.Theme, glamour.WithWordWrap(m.viewport.Width))
-	slide := m.Slides[m.Page]
+	slide := m.currentSlideContent()
 	slide = code.HideComments(slide)
 	slide, err := r.Render(slide)
 	slide = strings.ReplaceAll(slide, "\t", tabSpaces)
@@ -300,17 +338,196 @@ func (m *Model) CurrentPage() int {
 	return m.Page
 }
 
+// CurrentPart returns the current part the presentation is on.
+func (m *Model) CurrentPart() int {
+	return m.Part
+}
+
 // SetPage sets which page the presentation should render.
 func (m *Model) SetPage(page int) {
-	if m.Page == page {
+	m.SetPageAndPart(page, 0)
+}
+
+// SetPageAndPart sets which page and part the presentation should render.
+func (m *Model) SetPageAndPart(page int, part int) {
+	if len(m.Slides) == 0 {
+		m.Page = 0
+		m.Part = 0
+		m.VirtualText = ""
 		return
 	}
-
+	if page < 0 {
+		page = 0
+	}
+	if page >= len(m.Slides) {
+		page = len(m.Slides) - 1
+	}
+	maxPart := m.stepsInSlide(page) - 1
+	if part < 0 {
+		part = 0
+	}
+	if part > maxPart {
+		part = maxPart
+	}
+	if m.Page == page && m.Part == part {
+		return
+	}
 	m.VirtualText = ""
 	m.Page = page
+	m.Part = part
 }
 
 // Pages returns all the slides in the presentation.
 func (m *Model) Pages() []string {
-	return m.Slides
+	pages := make([]string, len(m.Slides))
+	for i, slide := range m.Slides {
+		pages[i] = strings.Join(slide.Parts, "\n")
+	}
+	return pages
+}
+
+// SlideParts returns the paused parts for a specific slide.
+func (m *Model) SlideParts(page int) []string {
+	if page < 0 || page >= len(m.Slides) {
+		return nil
+	}
+	parts := m.Slides[page].Parts
+	if len(parts) == 0 {
+		return []string{""}
+	}
+	return parts
+}
+
+func splitSlides(slides []string) []Slide {
+	parsed := make([]Slide, 0, len(slides))
+	for _, slide := range slides {
+		parts := strings.Split(slide, pausedDelimiter)
+		if len(parts) == 0 {
+			parts = []string{slide}
+		}
+		parsed = append(parsed, Slide{Parts: parts})
+	}
+	return parsed
+}
+
+func (m *Model) stepsInSlide(page int) int {
+	if page < 0 || page >= len(m.Slides) {
+		return 0
+	}
+	parts := m.Slides[page].Parts
+	if len(parts) == 0 {
+		return 1
+	}
+	return len(parts)
+}
+
+func (m *Model) currentSlideContent() string {
+	if len(m.Slides) == 0 {
+		return ""
+	}
+	parts := m.Slides[m.Page].Parts
+	if len(parts) == 0 {
+		return ""
+	}
+	part := m.Part
+	if part < 0 {
+		part = 0
+	}
+	if part >= len(parts) {
+		part = len(parts) - 1
+	}
+	return strings.Join(parts[:part+1], "\n")
+}
+
+func (m *Model) clampPosition() {
+	if len(m.Slides) == 0 {
+		m.Page = 0
+		m.Part = 0
+		return
+	}
+	if m.Page < 0 {
+		m.Page = 0
+	}
+	if m.Page >= len(m.Slides) {
+		m.Page = len(m.Slides) - 1
+	}
+	maxPart := m.stepsInSlide(m.Page) - 1
+	if m.Part < 0 {
+		m.Part = 0
+	}
+	if m.Part > maxPart {
+		m.Part = maxPart
+	}
+}
+
+func (m *Model) advanceSteps(steps int) {
+	if len(m.Slides) == 0 {
+		return
+	}
+	if steps < 0 {
+		m.retreatSteps(-steps)
+		return
+	}
+	for i := 0; i < steps; i++ {
+		parts := m.stepsInSlide(m.Page)
+		if parts == 0 {
+			return
+		}
+		if m.Part < parts-1 {
+			m.SetPageAndPart(m.Page, m.Part+1)
+			continue
+		}
+		if m.Page < len(m.Slides)-1 {
+			m.SetPageAndPart(m.Page+1, 0)
+			continue
+		}
+		break
+	}
+}
+
+func (m *Model) retreatSteps(steps int) {
+	if len(m.Slides) == 0 {
+		return
+	}
+	if steps < 0 {
+		m.advanceSteps(-steps)
+		return
+	}
+	for i := 0; i < steps; i++ {
+		if m.Part > 0 {
+			m.SetPageAndPart(m.Page, m.Part-1)
+			continue
+		}
+		if m.Page > 0 {
+			prevPage := m.Page - 1
+			m.SetPageAndPart(prevPage, m.stepsInSlide(prevPage)-1)
+			continue
+		}
+		break
+	}
+}
+
+func (m *Model) consumeRepeat() int {
+	if !bufferIsNumeric(m.buffer) {
+		m.buffer = ""
+		return 1
+	}
+	repeat, _ := strconv.Atoi(m.buffer)
+	m.buffer = ""
+	if repeat == 0 {
+		return 1
+	}
+	return repeat
+}
+
+func updateRepeatBuffer(buffer string, digit string) string {
+	if bufferIsNumeric(buffer) {
+		return buffer + digit
+	}
+	return digit
+}
+
+func bufferIsNumeric(buffer string) bool {
+	_, err := strconv.Atoi(buffer)
+	return err == nil
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -61,3 +61,54 @@ func TestCurrentSlideContentCumulative(t *testing.T) {
 		t.Fatalf("expected cumulative content, got %q", content)
 	}
 }
+
+func TestPagingFormats(t *testing.T) {
+	m := Model{
+		Slides: []Slide{
+			{Parts: []string{"a", "b", "c"}},
+			{Parts: []string{"d"}},
+		},
+	}
+	m.SetPageAndPart(0, 1)
+
+	tests := []struct {
+		format   string
+		expected string
+	}{
+		// No placeholder
+		{"Static", "Static"},
+		// 1 placeholder: slide
+		{"Slide %d", "Slide 1"},
+		// 2 placeholders: slide, totalSlides
+		{"Slide %d / %d", "Slide 1 / 2"},
+		// 3 placeholders: slide, totalSlides, part
+		{"Slide %d / %d | Part %d", "Slide 1 / 2 | Part 2"},
+		// 4+ placeholders: slide, totalSlides, part, totalParts
+		{"Slide %d / %d (Part %d / %d)", "Slide 1 / 2 (Part 2 / 3)"},
+	}
+
+	for _, tt := range tests {
+		m.Paging = tt.format
+		result := m.paging()
+		if result != tt.expected {
+			t.Errorf("format %q: expected %q, got %q", tt.format, tt.expected, result)
+		}
+	}
+}
+
+func TestPagingWithLastPart(t *testing.T) {
+	m := Model{
+		Slides: []Slide{
+			{Parts: []string{"a", "b"}},
+			{Parts: []string{"c", "d", "e"}},
+		},
+	}
+	m.SetPageAndPart(1, 2) // Last slide, last part
+	m.Paging = "Slide %d / %d (Part %d / %d)"
+
+	result := m.paging()
+	expected := "Slide 2 / 2 (Part 3 / 3)"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,0 +1,63 @@
+package model
+
+import "testing"
+
+func TestSplitSlidesWithPausedDelimiter(t *testing.T) {
+	slides := []string{
+		"# Title\nfirst\n+++\nsecond\n+++\nthird",
+		"# Next\nonly",
+	}
+
+	parsed := splitSlides(slides)
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 slides, got %d", len(parsed))
+	}
+	if len(parsed[0].Parts) != 3 {
+		t.Fatalf("expected 3 parts, got %d", len(parsed[0].Parts))
+	}
+	if parsed[0].Parts[1] != "second" {
+		t.Fatalf("expected second part to be %q, got %q", "second", parsed[0].Parts[1])
+	}
+	if len(parsed[1].Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(parsed[1].Parts))
+	}
+}
+
+func TestAdvanceRetreatSteps(t *testing.T) {
+	m := Model{
+		Slides: []Slide{
+			{Parts: []string{"a", "b"}},
+			{Parts: []string{"c", "d", "e"}},
+		},
+	}
+
+	m.SetPageAndPart(0, 0)
+	m.advanceSteps(1)
+	if m.Page != 0 || m.Part != 1 {
+		t.Fatalf("expected page 0 part 1, got page %d part %d", m.Page, m.Part)
+	}
+
+	m.advanceSteps(1)
+	if m.Page != 1 || m.Part != 0 {
+		t.Fatalf("expected page 1 part 0, got page %d part %d", m.Page, m.Part)
+	}
+
+	m.retreatSteps(1)
+	if m.Page != 0 || m.Part != 1 {
+		t.Fatalf("expected page 0 part 1 after retreat, got page %d part %d", m.Page, m.Part)
+	}
+}
+
+func TestCurrentSlideContentCumulative(t *testing.T) {
+	m := Model{
+		Slides: []Slide{
+			{Parts: []string{"first", "second", "third"}},
+		},
+	}
+	m.SetPageAndPart(0, 1)
+
+	content := m.currentSlideContent()
+	if content != "first\nsecond" {
+		t.Fatalf("expected cumulative content, got %q", content)
+	}
+}

--- a/internal/navigation/search.go
+++ b/internal/navigation/search.go
@@ -11,8 +11,11 @@ import (
 // Model is an interface for models.model, so that cycle imports are avoided
 type Model interface {
 	CurrentPage() int
+	CurrentPart() int
 	SetPage(page int)
+	SetPageAndPart(page int, part int)
 	Pages() []string
+	SlideParts(page int) []string
 }
 
 // Search represents the current search
@@ -72,10 +75,12 @@ func (s *Search) Execute(m Model) {
 		return
 	}
 	check := func(i int) bool {
-		content := m.Pages()[i]
-		if len(pattern.FindAllStringSubmatch(content, 1)) != 0 {
-			m.SetPage(i)
-			return true
+		parts := m.SlideParts(i)
+		for idx, part := range parts {
+			if len(pattern.FindAllStringSubmatch(part, 1)) != 0 {
+				m.SetPageAndPart(i, idx)
+				return true
+			}
 		}
 		return false
 	}

--- a/internal/navigation/search_test.go
+++ b/internal/navigation/search_test.go
@@ -7,18 +7,36 @@ import (
 type mockModel struct {
 	slides []string
 	page   int
+	part   int
 }
 
 func (m *mockModel) CurrentPage() int {
 	return m.page
 }
 
+func (m *mockModel) CurrentPart() int {
+	return m.part
+}
+
 func (m *mockModel) SetPage(page int) {
 	m.page = page
+	m.part = 0
+}
+
+func (m *mockModel) SetPageAndPart(page int, part int) {
+	m.page = page
+	m.part = part
 }
 
 func (m *mockModel) Pages() []string {
 	return m.slides
+}
+
+func (m *mockModel) SlideParts(page int) []string {
+	if page < 0 || page >= len(m.slides) {
+		return nil
+	}
+	return []string{m.slides[page]}
 }
 
 func TestSearch(t *testing.T) {


### PR DESCRIPTION
Hey, I'm preparing a presentation for the company I'm interning at and discovered this project. I love it and thought it could benefit from having paused slides. I looked at PR 293 from May 2024 and built on top of the ideas that were shared there.

I don't have much experience with Go so I'm open to criticism.

### Changes Introduced
- Introduces paused slide parts using a new +++ delimiter so navigation steps through parts before advancing slides
- Updates paging to support up to 4 %d directives (e.g., “Slide %d / %d (Part %d / %d)”) while keeping the default format unchanged
- Refactors slide parsing to split logical slides into parts and updates navigation/search handling
- Adds documentation and an example for paused slides
- Extends paging format handling and adds related tests
- Unit tests added/updated in model_test.go and search_test.go